### PR TITLE
Add Chunk type with rune-offset invariants

### DIFF
--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -1,0 +1,46 @@
+// Package chunk defines the unit of split text.
+package chunk
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+// Chunk is a contiguous slice of a document.
+//
+// Start and End are rune offsets into the original text and form a
+// half-open interval [Start, End). The number of runes in Text must
+// equal End - Start.
+type Chunk struct {
+	Text       string `json:"text"`
+	Start      int    `json:"start"`
+	End        int    `json:"end"`
+	TokenCount int    `json:"token_count"`
+}
+
+// New builds a Chunk and checks its invariants.
+func New(text string, start, end, tokenCount int) (Chunk, error) {
+	if start < 0 {
+		return Chunk{}, fmt.Errorf("start must be >= 0, got %d", start)
+	}
+	if end < start {
+		return Chunk{}, fmt.Errorf("end must be >= start, got start=%d end=%d", start, end)
+	}
+	if tokenCount < 0 {
+		return Chunk{}, fmt.Errorf("token_count must be >= 0, got %d", tokenCount)
+	}
+	runes := utf8.RuneCountInString(text)
+	if runes != end-start {
+		return Chunk{}, fmt.Errorf(
+			"text rune count %d must equal end-start %d",
+			runes,
+			end-start,
+		)
+	}
+	return Chunk{
+		Text:       text,
+		Start:      start,
+		End:        end,
+		TokenCount: tokenCount,
+	}, nil
+}

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -1,0 +1,116 @@
+package chunk
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		text       string
+		start      int
+		end        int
+		tokenCount int
+		wantErr    string
+	}{
+		{
+			name:       "ascii",
+			text:       "hello",
+			start:      0,
+			end:        5,
+			tokenCount: 5,
+		},
+		{
+			name:       "empty",
+			text:       "",
+			start:      3,
+			end:        3,
+			tokenCount: 0,
+		},
+		{
+			name:       "unicode runes not bytes",
+			text:       "你好",
+			start:      0,
+			end:        2,
+			tokenCount: 2,
+		},
+		{
+			name:    "negative start",
+			text:    "a",
+			start:   -1,
+			end:     0,
+			wantErr: "start must be >= 0",
+		},
+		{
+			name:    "end before start",
+			text:    "a",
+			start:   2,
+			end:     1,
+			wantErr: "end must be >= start",
+		},
+		{
+			name:       "negative token count",
+			text:       "a",
+			start:      0,
+			end:        1,
+			tokenCount: -1,
+			wantErr:    "token_count must be >= 0",
+		},
+		{
+			name:    "rune count mismatch uses bytes as end",
+			text:    "你好",
+			start:   0,
+			end:     6,
+			wantErr: "text rune count 2 must equal end-start 6",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := New(tt.text, tt.start, tt.end, tt.tokenCount)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Text != tt.text || got.Start != tt.start || got.End != tt.end || got.TokenCount != tt.tokenCount {
+				t.Fatalf("got %+v", got)
+			}
+		})
+	}
+}
+
+func TestChunkJSON(t *testing.T) {
+	t.Parallel()
+
+	c, err := New("hi", 0, 2, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := json.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got Chunk
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got != c {
+		t.Fatalf("round trip: got %+v want %+v", got, c)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pkg/chunk` as the first library package.
- `Chunk` stores text plus a half-open `[Start, End)` range counted in Unicode code points (`rune`), not bytes.
- `New` rejects negative offsets, inverted ranges, negative token counts, and rune-count mismatches.

## Test plan
- [x] `go test ./...`
- [ ] Review the unicode case: `"你好"` is 2 runes / 6 bytes; `end` must be 2.