### PR TITLE
Add split-invariant checks for chunker tests

### DIFF
--- a/internal/assertchunk/check.go
+++ b/internal/assertchunk/check.go
@@ -1,0 +1,73 @@
+// Package assertchunk checks split invariants used by chunker tests.
+package assertchunk
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+)
+
+// Check reports whether chunks are a complete, non-overlapping split of original.
+//
+// The expected invariants:
+//   - the first chunk starts at rune 0
+//   - adjacent chunks meet (previous End equals next Start)
+//   - the last chunk ends at the rune count of original
+//   - each chunk.Text equals original[Start:End] in rune space
+//   - concatenating chunk texts equals original
+func Check(original string, chunks []chunk.Chunk) error {
+	runes := []rune(original)
+
+	if len(chunks) == 0 {
+		if original != "" {
+			return fmt.Errorf("empty chunk list does not cover %d-rune original", len(runes))
+		}
+		return nil
+	}
+
+	if chunks[0].Start != 0 {
+		return fmt.Errorf("first chunk start is %d, want 0", chunks[0].Start)
+	}
+	if last := chunks[len(chunks)-1]; last.End != len(runes) {
+		return fmt.Errorf("last chunk end is %d, want %d", last.End, len(runes))
+	}
+
+	var b strings.Builder
+	for i, c := range chunks {
+		if i > 0 {
+			prev := chunks[i-1]
+			if prev.End != c.Start {
+				return fmt.Errorf(
+					"gap or overlap between chunk %d end %d and chunk %d start %d",
+					i-1, prev.End, i, c.Start,
+				)
+			}
+		}
+		if c.Start < 0 || c.End > len(runes) {
+			return fmt.Errorf(
+				"chunk %d range [%d, %d) is outside original of %d runes",
+				i, c.Start, c.End, len(runes),
+			)
+		}
+		got := string(runes[c.Start:c.End])
+		if got != c.Text {
+			return fmt.Errorf("chunk %d text does not match original[%d:%d]", i, c.Start, c.End)
+		}
+		b.WriteString(c.Text)
+	}
+
+	if b.String() != original {
+		return fmt.Errorf("concatenated chunks do not equal original")
+	}
+	return nil
+}
+
+// Split fails the test if chunks are not a complete, non-overlapping split of original.
+func Split(t testing.TB, original string, chunks []chunk.Chunk) {
+	t.Helper()
+	if err := Check(original, chunks); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/assertchunk/check_test.go
+++ b/internal/assertchunk/check_test.go
@@ -1,0 +1,119 @@
+package assertchunk
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+)
+
+func mustChunk(t *testing.T, text string, start, end, tokenCount int) chunk.Chunk {
+	t.Helper()
+	c, err := chunk.New(text, start, end, tokenCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestCheck(t *testing.T) {
+	t.Parallel()
+
+	hello := mustChunk(t, "hello", 0, 5, 5)
+	nihao := mustChunk(t, "你好", 0, 2, 2)
+
+	tests := []struct {
+		name     string
+		original string
+		chunks   []chunk.Chunk
+		wantErr  string
+	}{
+		{
+			name:     "empty original",
+			original: "",
+			chunks:   nil,
+		},
+		{
+			name:     "single chunk",
+			original: "hello",
+			chunks:   []chunk.Chunk{hello},
+		},
+		{
+			name:     "two chunks",
+			original: "hello",
+			chunks: []chunk.Chunk{
+				mustChunk(t, "he", 0, 2, 2),
+				mustChunk(t, "llo", 2, 5, 3),
+			},
+		},
+		{
+			name:     "unicode runes",
+			original: "你好",
+			chunks:   []chunk.Chunk{nihao},
+		},
+		{
+			name:     "empty list for non-empty original",
+			original: "hello",
+			chunks:   nil,
+			wantErr:  "empty chunk list",
+		},
+		{
+			name:     "first start not zero",
+			original: "hello",
+			chunks:   []chunk.Chunk{mustChunk(t, "ello", 1, 5, 4)},
+			wantErr:  "first chunk start is 1, want 0",
+		},
+		{
+			name:     "last end short",
+			original: "hello",
+			chunks:   []chunk.Chunk{mustChunk(t, "hel", 0, 3, 3)},
+			wantErr:  "last chunk end is 3, want 5",
+		},
+		{
+			name:     "gap",
+			original: "hello",
+			chunks: []chunk.Chunk{
+				mustChunk(t, "he", 0, 2, 2),
+				mustChunk(t, "lo", 3, 5, 2),
+			},
+			wantErr: "gap or overlap",
+		},
+		{
+			name:     "text does not match original",
+			original: "hello",
+			chunks:   []chunk.Chunk{mustChunk(t, "world", 0, 5, 5)},
+			wantErr:  "text does not match original",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := Check(tt.original, tt.chunks)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSplitPasses(t *testing.T) {
+	t.Parallel()
+
+	original := "你好世界"
+	chunks := []chunk.Chunk{
+		mustChunk(t, "你好", 0, 2, 2),
+		mustChunk(t, "世界", 2, 4, 2),
+	}
+	Split(t, original, chunks)
+}


### PR DESCRIPTION
## Summary
- Add `internal/assertchunk` so later chunkers can share one set of split checks.
- A valid split covers the original in rune space, has no gaps or overlap, and concatenates back to the source.
- `Check` returns an error (easy to unit-test); `Split` fails the calling test.

## Test plan
- [x] `go test ./...`
- [ ] Skim the unicode case (`你好世界` split into two 2-rune chunks).