### PR TITLE
Add Tokenizer interface and character tokenizer

### DIFF
--- a/pkg/tokenizer/character.go
+++ b/pkg/tokenizer/character.go
@@ -1,0 +1,31 @@
+package tokenizer
+
+import "unicode/utf8"
+
+// Character treats each Unicode code point as one token.
+// The token id is the rune value itself.
+type Character struct{}
+
+// Encode maps each rune in text to its code point.
+func (Character) Encode(text string) []int {
+	n := utf8.RuneCountInString(text)
+	ids := make([]int, 0, n)
+	for _, r := range text {
+		ids = append(ids, int(r))
+	}
+	return ids
+}
+
+// Decode concatenates token ids as runes.
+func (Character) Decode(tokens []int) string {
+	runes := make([]rune, len(tokens))
+	for i, id := range tokens {
+		runes[i] = rune(id)
+	}
+	return string(runes)
+}
+
+// Count returns the number of runes in text.
+func (Character) Count(text string) int {
+	return utf8.RuneCountInString(text)
+}

--- a/pkg/tokenizer/character_test.go
+++ b/pkg/tokenizer/character_test.go
@@ -1,0 +1,59 @@
+package tokenizer
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestCharacterRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tok := Character{}
+	tests := []string{
+		"",
+		"hello",
+		"你好",
+		"👍",
+		"Go 1.26",
+	}
+
+	for _, text := range tests {
+		t.Run(fmt.Sprintf("%q", text), func(t *testing.T) {
+			t.Parallel()
+
+			ids := tok.Encode(text)
+			if tok.Count(text) != len(ids) {
+				t.Fatalf("Count=%d len(Encode)=%d", tok.Count(text), len(ids))
+			}
+			if tok.Count(text) != utf8.RuneCountInString(text) {
+				t.Fatalf("Count=%d rune count=%d", tok.Count(text), utf8.RuneCountInString(text))
+			}
+			got := tok.Decode(ids)
+			if got != text {
+				t.Fatalf("Decode(Encode(%q)) = %q", text, got)
+			}
+		})
+	}
+}
+
+func TestCharacterEncodeIDs(t *testing.T) {
+	t.Parallel()
+
+	got := Character{}.Encode("ab你")
+	want := []int{'a', 'b', '你'}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestCharacterCountNotBytes(t *testing.T) {
+	t.Parallel()
+
+	text := "你好"
+	got := Character{}.Count(text)
+	if got != 2 {
+		t.Fatalf("Count(%q)=%d, want 2 runes (not %d bytes)", text, got, len(text))
+	}
+}

--- a/pkg/tokenizer/tokenizer.go
+++ b/pkg/tokenizer/tokenizer.go
@@ -1,0 +1,12 @@
+// Package tokenizer counts and maps text for chunk size limits.
+package tokenizer
+
+// Tokenizer is the ruler used to measure and split text.
+//
+// Encode and Decode must round-trip valid Unicode text.
+// Count(text) must equal len(Encode(text)).
+type Tokenizer interface {
+	Encode(text string) []int
+	Decode(tokens []int) string
+	Count(text string) int
+}


### PR DESCRIPTION
## Summary
- Add `pkg/tokenizer.Tokenizer` with `Encode`, `Decode`, and `Count`.
- `Count(text)` must equal `len(Encode(text))`; `Decode` must round-trip `Encode`.
- `Character` counts Unicode code points. `"你好"` is 2 tokens, not 6 bytes.

## Test plan
- [x] `go test ./...`
- [ ] Check the `"你好"` case: count is 2, encode/decode round-trips.