### PR TITLE
Add word tokenizer and fixed-window token chunker

### DIFF
--- a/pkg/tokenchunker/chunker.go
+++ b/pkg/tokenchunker/chunker.go
@@ -1,0 +1,68 @@
+// Package tokenchunker splits text into windows of a fixed token count.
+package tokenchunker
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+// Chunker splits text into windows of Size tokens.
+// Overlap is the number of tokens shared with the previous window.
+type Chunker struct {
+	tok     tokenizer.Tokenizer
+	size    int
+	overlap int
+}
+
+// New builds a Chunker.
+func New(tok tokenizer.Tokenizer, size, overlap int) (Chunker, error) {
+	if tok == nil {
+		return Chunker{}, fmt.Errorf("tokenizer is required")
+	}
+	if size <= 0 {
+		return Chunker{}, fmt.Errorf("size must be > 0, got %d", size)
+	}
+	if overlap < 0 {
+		return Chunker{}, fmt.Errorf("overlap must be >= 0, got %d", overlap)
+	}
+	if overlap >= size {
+		return Chunker{}, fmt.Errorf("overlap must be < size, got overlap=%d size=%d", overlap, size)
+	}
+	return Chunker{tok: tok, size: size, overlap: overlap}, nil
+}
+
+// Chunk splits text into token windows.
+func (c Chunker) Chunk(text string) ([]chunk.Chunk, error) {
+	parts := c.tok.Split(text)
+	if len(parts) == 0 {
+		return nil, nil
+	}
+
+	starts := make([]int, len(parts)+1)
+	for i, p := range parts {
+		starts[i+1] = starts[i] + utf8.RuneCountInString(p)
+	}
+
+	step := c.size - c.overlap
+	out := make([]chunk.Chunk, 0, (len(parts)+step-1)/step)
+	for i := 0; i < len(parts); i += step {
+		end := i + c.size
+		if end > len(parts) {
+			end = len(parts)
+		}
+		piece := strings.Join(parts[i:end], "")
+		ch, err := chunk.New(piece, starts[i], starts[end], end-i)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ch)
+		if end == len(parts) {
+			break
+		}
+	}
+	return out, nil
+}

--- a/pkg/tokenchunker/chunker_test.go
+++ b/pkg/tokenchunker/chunker_test.go
@@ -1,0 +1,203 @@
+package tokenchunker
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/bluesky585/nibble/internal/assertchunk"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		tok     tokenizer.Tokenizer
+		size    int
+		overlap int
+		wantErr string
+	}{
+		{name: "ok", tok: tokenizer.Character{}, size: 8, overlap: 0},
+		{name: "nil tokenizer", tok: nil, size: 8, overlap: 0, wantErr: "tokenizer is required"},
+		{name: "size zero", tok: tokenizer.Character{}, size: 0, overlap: 0, wantErr: "size must be > 0"},
+		{name: "negative overlap", tok: tokenizer.Character{}, size: 8, overlap: -1, wantErr: "overlap must be >= 0"},
+		{name: "overlap equals size", tok: tokenizer.Character{}, size: 4, overlap: 4, wantErr: "overlap must be < size"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := New(tt.tok, tt.size, tt.overlap)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestChunkCharacterNoOverlap(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "hello"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len=%d want 3", len(got))
+	}
+	if got[0].Text != "he" || got[1].Text != "ll" || got[2].Text != "o" {
+		t.Fatalf("texts=%q %q %q", got[0].Text, got[1].Text, got[2].Text)
+	}
+	assertchunk.Split(t, original, got)
+}
+
+func TestChunkUnicode(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "你好"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].Text != "你" || got[1].Text != "好" {
+		t.Fatalf("got %+v", got)
+	}
+	if got[0].End != 1 || got[1].Start != 1 || got[1].End != 2 {
+		t.Fatalf("offsets %+v %+v (2 runes, not 6 bytes)", got[0], got[1])
+	}
+	assertchunk.Split(t, original, got)
+}
+
+func TestChunkEmpty(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 8, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.Chunk("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, "", got)
+}
+
+func TestChunkShorterThanSize(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 64, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := "hi"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Text != original || got[0].TokenCount != 2 {
+		t.Fatalf("got %+v", got)
+	}
+	assertchunk.Split(t, original, got)
+}
+
+func TestChunkWord(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Word{}, 3, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "hello world" -> ["hello", " ", "world"] : one chunk of 3 tokens
+	original := "hello world"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Text != original {
+		t.Fatalf("got %+v", got)
+	}
+	assertchunk.Split(t, original, got)
+
+	original = "one two three four"
+	got, err = c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+}
+
+func TestChunkOverlap(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 3, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "hello"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d want 2", len(got))
+	}
+	if got[0].Text != "hel" || got[1].Text != "llo" {
+		t.Fatalf("texts=%q %q", got[0].Text, got[1].Text)
+	}
+	if got[1].Start != 2 {
+		t.Fatalf("overlap start=%d want 2", got[1].Start)
+	}
+
+	runes := []rune(original)
+	if got[0].Start != 0 || got[len(got)-1].End != len(runes) {
+		t.Fatalf("does not cover original: %+v", got)
+	}
+	for i, ch := range got {
+		slice := string(runes[ch.Start:ch.End])
+		if slice != ch.Text {
+			t.Fatalf("chunk %d text %q != original[%d:%d] %q", i, ch.Text, ch.Start, ch.End, slice)
+		}
+	}
+	if err := assertchunk.Check(original, got); err == nil {
+		t.Fatal("overlap split should fail the no-gap reconstruct check")
+	}
+}
+
+func TestChunkTokenCount(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.Chunk("你好世界")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if utf8.RuneCountInString("你好世界") != 4 {
+		t.Fatal("precondition")
+	}
+	if got[0].TokenCount != 2 || got[1].TokenCount != 2 {
+		t.Fatalf("token counts %+v %+v", got[0], got[1])
+	}
+}

--- a/pkg/tokenizer/character.go
+++ b/pkg/tokenizer/character.go
@@ -6,6 +6,18 @@ import "unicode/utf8"
 // The token id is the rune value itself.
 type Character struct{}
 
+// Split returns one piece per rune.
+func (Character) Split(text string) []string {
+	if text == "" {
+		return nil
+	}
+	parts := make([]string, 0, utf8.RuneCountInString(text))
+	for _, r := range text {
+		parts = append(parts, string(r))
+	}
+	return parts
+}
+
 // Encode maps each rune in text to its code point.
 func (Character) Encode(text string) []int {
 	n := utf8.RuneCountInString(text)

--- a/pkg/tokenizer/character_test.go
+++ b/pkg/tokenizer/character_test.go
@@ -34,6 +34,13 @@ func TestCharacterRoundTrip(t *testing.T) {
 			if got != text {
 				t.Fatalf("Decode(Encode(%q)) = %q", text, got)
 			}
+			parts := tok.Split(text)
+			if tok.Count(text) != len(parts) {
+				t.Fatalf("Count=%d len(Split)=%d", tok.Count(text), len(parts))
+			}
+			if Join(parts) != text {
+				t.Fatalf("Join(Split(%q)) = %q", text, Join(parts))
+			}
 		})
 	}
 }

--- a/pkg/tokenizer/tokenizer.go
+++ b/pkg/tokenizer/tokenizer.go
@@ -1,12 +1,18 @@
 // Package tokenizer counts and maps text for chunk size limits.
 package tokenizer
 
+import "strings"
+
 // Tokenizer is the ruler used to measure and split text.
 //
-// Encode and Decode must round-trip valid Unicode text.
-// Count(text) must equal len(Encode(text)).
+// Split must return pieces that concatenate to the original text.
+// Count(text) must equal len(Split(text)).
 type Tokenizer interface {
-	Encode(text string) []int
-	Decode(tokens []int) string
+	Split(text string) []string
 	Count(text string) int
+}
+
+// Join concatenates token pieces. It is the inverse of a correct Split.
+func Join(parts []string) string {
+	return strings.Join(parts, "")
 }

--- a/pkg/tokenizer/word.go
+++ b/pkg/tokenizer/word.go
@@ -1,0 +1,38 @@
+package tokenizer
+
+import "unicode"
+
+// Word splits on Unicode whitespace. Each run of non-space runes and
+// each run of space runes is one token, so Join(Split(text)) == text.
+type Word struct{}
+
+// Split returns word and whitespace runs.
+func (Word) Split(text string) []string {
+	if text == "" {
+		return nil
+	}
+
+	var parts []string
+	var b []rune
+	lastSpace := false
+	started := false
+	for _, r := range text {
+		space := unicode.IsSpace(r)
+		if !started {
+			lastSpace = space
+			started = true
+		} else if space != lastSpace {
+			parts = append(parts, string(b))
+			b = b[:0]
+			lastSpace = space
+		}
+		b = append(b, r)
+	}
+	parts = append(parts, string(b))
+	return parts
+}
+
+// Count returns the number of word and whitespace runs.
+func (Word) Count(text string) int {
+	return len(Word{}.Split(text))
+}

--- a/pkg/tokenizer/word_test.go
+++ b/pkg/tokenizer/word_test.go
@@ -1,0 +1,43 @@
+package tokenizer
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestWordSplit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		text string
+		want []string
+	}{
+		{text: "", want: nil},
+		{text: "hello", want: []string{"hello"}},
+		{text: "hello world", want: []string{"hello", " ", "world"}},
+		{text: "hello  world", want: []string{"hello", "  ", "world"}},
+		{text: "  a", want: []string{"  ", "a"}},
+		{text: "a  ", want: []string{"a", "  "}},
+		{text: "你好 世界", want: []string{"你好", " ", "世界"}},
+		{text: "one\ntwo", want: []string{"one", "\n", "two"}},
+	}
+
+	tok := Word{}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q", tt.text), func(t *testing.T) {
+			t.Parallel()
+
+			got := tok.Split(tt.text)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Split(%q)=%q want %q", tt.text, got, tt.want)
+			}
+			if tok.Count(tt.text) != len(got) {
+				t.Fatalf("Count=%d len(Split)=%d", tok.Count(tt.text), len(got))
+			}
+			if Join(got) != tt.text {
+				t.Fatalf("Join(Split(%q))=%q", tt.text, Join(got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Tokenizer.Split`: pieces must concatenate to the original (`Join(Split(text)) == text`).
- Add `Word`: each run of non-space or space runes is one token, so spaces are not dropped.
- Add `tokenchunker.Chunker`: fixed token windows, optional overlap.
- No-overlap splits still pass `assertchunk`. Overlap shares tokens; indices are still rune-accurate.

## Test plan
- [x] `go test ./...`
- [ ] `"你好"` with character size 1: two chunks, offsets 0-1 and 1-2 (not bytes).
- [ ] `"hello"` with size 3 overlap 1: `hel` then `llo`, second start is 2.