### PR TITLE
Add delimiter split and sentence chunker

### DIFF
--- a/pkg/sentencechunker/chunker.go
+++ b/pkg/sentencechunker/chunker.go
@@ -1,0 +1,90 @@
+// Package sentencechunker splits on sentence delimiters, then packs
+// sentences into chunks up to a token budget.
+package sentencechunker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/split"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+// DefaultDelimiters are common sentence endings, including CJK.
+var DefaultDelimiters = []string{"。", "！", "？", ".", "!", "?"}
+
+// Chunker splits on sentence delimiters and merges until Size tokens.
+// A single sentence longer than Size is emitted whole.
+type Chunker struct {
+	tok    tokenizer.Tokenizer
+	size   int
+	delims []string
+}
+
+// New builds a Chunker. delims defaults to DefaultDelimiters when empty.
+func New(tok tokenizer.Tokenizer, size int, delims []string) (Chunker, error) {
+	if tok == nil {
+		return Chunker{}, fmt.Errorf("tokenizer is required")
+	}
+	if size <= 0 {
+		return Chunker{}, fmt.Errorf("size must be > 0, got %d", size)
+	}
+	if len(delims) == 0 {
+		delims = append([]string(nil), DefaultDelimiters...)
+	}
+	return Chunker{tok: tok, size: size, delims: delims}, nil
+}
+
+// Chunk splits text into sentence-packed windows.
+func (c Chunker) Chunk(text string) ([]chunk.Chunk, error) {
+	pieces, err := split.Text(text, split.Options{
+		Delimiters: c.delims,
+		Attach:     split.AttachPrev,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(pieces) == 0 {
+		return nil, nil
+	}
+
+	var out []chunk.Chunk
+	var buf []split.Piece
+	tokens := 0
+
+	flush := func() error {
+		if len(buf) == 0 {
+			return nil
+		}
+		var b strings.Builder
+		n := 0
+		for _, p := range buf {
+			b.WriteString(p.Text)
+			n += c.tok.Count(p.Text)
+		}
+		ch, err := chunk.New(b.String(), buf[0].Start, buf[len(buf)-1].End, n)
+		if err != nil {
+			return err
+		}
+		out = append(out, ch)
+		buf = buf[:0]
+		tokens = 0
+		return nil
+	}
+
+	for _, p := range pieces {
+		n := c.tok.Count(p.Text)
+		if len(buf) > 0 && tokens+n > c.size {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+		}
+		buf = append(buf, p)
+		tokens += n
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/pkg/sentencechunker/chunker_test.go
+++ b/pkg/sentencechunker/chunker_test.go
@@ -1,0 +1,126 @@
+package sentencechunker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bluesky585/nibble/internal/assertchunk"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(nil, 8, nil)
+	if err == nil || !strings.Contains(err.Error(), "tokenizer is required") {
+		t.Fatalf("err=%v", err)
+	}
+	_, err = New(tokenizer.Character{}, 0, nil)
+	if err == nil || !strings.Contains(err.Error(), "size must be > 0") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestChunkPacksSentences(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 20, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "Hello. How are you? Fine!"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if len(got) != 2 {
+		t.Fatalf("len=%d want 2 (Hello. How are you? | Fine!)", len(got))
+	}
+	if got[0].Text != "Hello. How are you?" {
+		t.Fatalf("first=%q", got[0].Text)
+	}
+	if got[1].Text != " Fine!" {
+		t.Fatalf("second=%q", got[1].Text)
+	}
+}
+
+func TestChunkOversizedSentence(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 4, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "Hello. Hi."
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "Hello." is 6 runes > 4, emitted whole; " Hi." is 4.
+	assertchunk.Split(t, original, got)
+	if len(got) != 2 || got[0].Text != "Hello." || got[1].Text != " Hi." {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestChunkCJK(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 8, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "你好。世界！"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if got[0].End != utf8Count(got[0].Text) {
+		t.Fatalf("offsets should be runes: %+v", got[0])
+	}
+}
+
+func TestChunkEmpty(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 8, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.Chunk("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, "", got)
+}
+
+func TestChunkNoSentenceDelim(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 8, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := "no punctuation here"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Text != original {
+		t.Fatalf("got %+v", got)
+	}
+	assertchunk.Split(t, original, got)
+}
+
+func utf8Count(s string) int {
+	n := 0
+	for range s {
+		n++
+	}
+	return n
+}

--- a/pkg/split/split.go
+++ b/pkg/split/split.go
@@ -1,0 +1,141 @@
+// Package split cuts text on delimiters without dropping any characters.
+package split
+
+import (
+	"fmt"
+	"sort"
+	"unicode/utf8"
+)
+
+// Attach controls which piece a matched delimiter belongs to.
+type Attach int
+
+const (
+	// AttachPrev puts the delimiter at the end of the preceding piece.
+	AttachPrev Attach = iota
+	// AttachNext puts the delimiter at the start of the following piece.
+	AttachNext
+	// AttachOwn keeps the delimiter as its own piece.
+	AttachOwn
+)
+
+// Options configure a delimiter split.
+type Options struct {
+	Delimiters []string
+	Attach     Attach
+	// MinRunes merges a piece with the next ones until it has at least
+	// this many runes. The last piece may still be shorter. 0 disables merging.
+	MinRunes int
+}
+
+// Piece is a substring of the original text in rune offsets [Start, End).
+type Piece struct {
+	Text  string
+	Start int
+	End   int
+}
+
+// Text splits text on Delimiters. Join of piece texts always equals text.
+func Text(text string, opt Options) ([]Piece, error) {
+	if opt.MinRunes < 0 {
+		return nil, fmt.Errorf("MinRunes must be >= 0, got %d", opt.MinRunes)
+	}
+	switch opt.Attach {
+	case AttachPrev, AttachNext, AttachOwn:
+	default:
+		return nil, fmt.Errorf("unknown Attach %d", opt.Attach)
+	}
+	for _, d := range opt.Delimiters {
+		if d == "" {
+			return nil, fmt.Errorf("delimiters must not be empty strings")
+		}
+	}
+	if text == "" {
+		return nil, nil
+	}
+	if len(opt.Delimiters) == 0 {
+		n := utf8.RuneCountInString(text)
+		return []Piece{{Text: text, Start: 0, End: n}}, nil
+	}
+
+	delims := append([]string(nil), opt.Delimiters...)
+	sort.SliceStable(delims, func(i, j int) bool {
+		return len(delims[i]) > len(delims[j])
+	})
+
+	pieces := make([]Piece, 0, 8)
+	startB, startR := 0, 0
+	b, r := 0, 0
+
+	emit := func(endB, endR int) {
+		if endB < startB {
+			return
+		}
+		if endB == startB {
+			return
+		}
+		pieces = append(pieces, Piece{
+			Text:  text[startB:endB],
+			Start: startR,
+			End:   endR,
+		})
+		startB, startR = endB, endR
+	}
+
+	for b < len(text) {
+		if d, ok := match(delims, text[b:]); ok {
+			endB := b + len(d)
+			endR := r + utf8.RuneCountInString(d)
+			switch opt.Attach {
+			case AttachPrev:
+				emit(endB, endR)
+			case AttachNext:
+				emit(b, r)
+				startB, startR = b, r
+			case AttachOwn:
+				emit(b, r)
+				startB, startR = b, r
+				emit(endB, endR)
+			}
+			b, r = endB, endR
+			continue
+		}
+		_, w := utf8.DecodeRuneInString(text[b:])
+		b += w
+		r++
+	}
+	if startB < len(text) {
+		emit(len(text), r)
+	}
+
+	return mergeShort(pieces, opt.MinRunes), nil
+}
+
+func match(delims []string, rest string) (string, bool) {
+	for _, d := range delims {
+		if len(d) <= len(rest) && rest[:len(d)] == d {
+			return d, true
+		}
+	}
+	return "", false
+}
+
+func mergeShort(pieces []Piece, min int) []Piece {
+	if min <= 0 || len(pieces) < 2 {
+		return pieces
+	}
+
+	out := make([]Piece, 0, len(pieces))
+	cur := pieces[0]
+	for _, p := range pieces[1:] {
+		if utf8.RuneCountInString(cur.Text) < min {
+			cur.Text += p.Text
+			cur.End = p.End
+			continue
+		}
+		out = append(out, cur)
+		cur = p
+	}
+	out = append(out, cur)
+	return out
+}

--- a/pkg/split/split_test.go
+++ b/pkg/split/split_test.go
@@ -1,0 +1,180 @@
+package split
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func texts(pieces []Piece) []string {
+	out := make([]string, len(pieces))
+	for i, p := range pieces {
+		out[i] = p.Text
+	}
+	return out
+}
+
+func assertPieces(t *testing.T, original string, pieces []Piece) {
+	t.Helper()
+	var b strings.Builder
+	runes := []rune(original)
+	for i, p := range pieces {
+		b.WriteString(p.Text)
+		if p.Start < 0 || p.End > len(runes) || p.Start > p.End {
+			t.Fatalf("piece %d range [%d, %d) invalid for %d runes", i, p.Start, p.End, len(runes))
+		}
+		if string(runes[p.Start:p.End]) != p.Text {
+			t.Fatalf("piece %d text %q != original[%d:%d]", i, p.Text, p.Start, p.End)
+		}
+		if i > 0 && pieces[i-1].End != p.Start {
+			t.Fatalf("gap at %d: prev end %d start %d", i, pieces[i-1].End, p.Start)
+		}
+	}
+	if b.String() != original {
+		t.Fatalf("join=%q want %q", b.String(), original)
+	}
+	if len(pieces) > 0 {
+		if pieces[0].Start != 0 || pieces[len(pieces)-1].End != utf8.RuneCountInString(original) {
+			t.Fatalf("pieces do not cover original: first=%d last=%d n=%d",
+				pieces[0].Start, pieces[len(pieces)-1].End, utf8.RuneCountInString(original))
+		}
+	}
+}
+
+func TestTextAttach(t *testing.T) {
+	t.Parallel()
+
+	original := "a.b.c"
+	tests := []struct {
+		name   string
+		attach Attach
+		want   []string
+	}{
+		{name: "prev", attach: AttachPrev, want: []string{"a.", "b.", "c"}},
+		{name: "next", attach: AttachNext, want: []string{"a", ".b", ".c"}},
+		{name: "own", attach: AttachOwn, want: []string{"a", ".", "b", ".", "c"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Text(original, Options{Delimiters: []string{"."}, Attach: tt.attach})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Join(texts(got), "|") != strings.Join(tt.want, "|") {
+				t.Fatalf("got %q want %q", texts(got), tt.want)
+			}
+			assertPieces(t, original, got)
+		})
+	}
+}
+
+func TestTextConsecutiveDelims(t *testing.T) {
+	t.Parallel()
+
+	original := "a..b"
+	got, err := Text(original, Options{Delimiters: []string{"."}, Attach: AttachPrev})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"a.", ".", "b"}
+	if strings.Join(texts(got), "|") != strings.Join(want, "|") {
+		t.Fatalf("got %q want %q", texts(got), want)
+	}
+	assertPieces(t, original, got)
+}
+
+func TestTextLongestDelimiter(t *testing.T) {
+	t.Parallel()
+
+	original := "hello\n\nworld\nend"
+	got, err := Text(original, Options{
+		Delimiters: []string{"\n", "\n\n"},
+		Attach:     AttachPrev,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"hello\n\n", "world\n", "end"}
+	if strings.Join(texts(got), "|") != strings.Join(want, "|") {
+		t.Fatalf("got %q want %q", texts(got), want)
+	}
+	assertPieces(t, original, got)
+}
+
+func TestTextUnicode(t *testing.T) {
+	t.Parallel()
+
+	original := "你好。世界"
+	got, err := Text(original, Options{Delimiters: []string{"。"}, Attach: AttachPrev})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].Text != "你好。" || got[1].Text != "世界" {
+		t.Fatalf("got %+v", got)
+	}
+	if got[0].End != 3 || got[1].Start != 3 || got[1].End != 5 {
+		t.Fatalf("rune offsets %+v %+v", got[0], got[1])
+	}
+	assertPieces(t, original, got)
+}
+
+func TestTextMinRunes(t *testing.T) {
+	t.Parallel()
+
+	original := "a.b.c.d"
+	got, err := Text(original, Options{
+		Delimiters: []string{"."},
+		Attach:     AttachPrev,
+		MinRunes:   4,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "a." (2) + "b." (2) => "a.b." (4), then "c." + "d" => "c.d"
+	want := []string{"a.b.", "c.d"}
+	if strings.Join(texts(got), "|") != strings.Join(want, "|") {
+		t.Fatalf("got %q want %q", texts(got), want)
+	}
+	assertPieces(t, original, got)
+}
+
+func TestTextNoDelimiter(t *testing.T) {
+	t.Parallel()
+
+	original := "hello"
+	got, err := Text(original, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Text != original {
+		t.Fatalf("got %+v", got)
+	}
+	assertPieces(t, original, got)
+}
+
+func TestTextEmpty(t *testing.T) {
+	t.Parallel()
+
+	got, err := Text("", Options{Delimiters: []string{"."}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestTextErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := Text("a", Options{Delimiters: []string{""}})
+	if err == nil {
+		t.Fatal("expected empty delimiter error")
+	}
+	_, err = Text("a", Options{MinRunes: -1})
+	if err == nil {
+		t.Fatal("expected MinRunes error")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pkg/split`: lossless delimiter cuts with `AttachPrev` / `AttachNext` / `AttachOwn`, longest-match, optional `MinRunes` merge.
- Piece offsets are rune ranges; concatenating piece texts always equals the original.
- Add `sentencechunker`: split on `.!?` and CJK `。！？`, then pack sentences up to a token budget. Oversized sentences are kept whole.

## Test plan
- [x] `go test ./...`
- [ ] `"a.b.c"` attach prev → `a.` `b.` `c`; next → `a` `.b` `.c`.
- [ ] `"hello\\n\\nworld\\nend"` prefers `\\n\\n` over `\\n`.
- [ ] `"你好。世界"` offsets are 0-3 and 3-5, not byte offsets.