### PR TITLE
Add recursive chunker with coarse-to-fine rules

### DIFF
--- a/pkg/recursive/chunker.go
+++ b/pkg/recursive/chunker.go
@@ -1,0 +1,157 @@
+// Package recursive splits text from coarse structure down to tokens.
+package recursive
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/split"
+	"github.com/bluesky585/nibble/pkg/tokenchunker"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+// Chunker packs delimiter pieces up to Size tokens. A piece that still
+// exceeds Size is split with the next Level.
+type Chunker struct {
+	tok   tokenizer.Tokenizer
+	size  int
+	rules []Level
+	hard  tokenchunker.Chunker
+}
+
+// New builds a Chunker. Empty rules use DefaultRules.
+func New(tok tokenizer.Tokenizer, size int, rules []Level) (Chunker, error) {
+	if tok == nil {
+		return Chunker{}, fmt.Errorf("tokenizer is required")
+	}
+	if size <= 0 {
+		return Chunker{}, fmt.Errorf("size must be > 0, got %d", size)
+	}
+	if len(rules) == 0 {
+		rules = DefaultRules()
+	} else {
+		rules = append([]Level(nil), rules...)
+		for _, l := range rules {
+			if err := l.validate(); err != nil {
+				return Chunker{}, err
+			}
+		}
+	}
+	hard, err := tokenchunker.New(tok, size, 0)
+	if err != nil {
+		return Chunker{}, err
+	}
+	return Chunker{tok: tok, size: size, rules: rules, hard: hard}, nil
+}
+
+// Chunk splits text using the rule stack.
+func (c Chunker) Chunk(text string) ([]chunk.Chunk, error) {
+	return c.chunkAt(text, 0, 0)
+}
+
+func (c Chunker) chunkAt(text string, level, offset int) ([]chunk.Chunk, error) {
+	if text == "" {
+		return nil, nil
+	}
+
+	n := c.tok.Count(text)
+	runes := utf8.RuneCountInString(text)
+	if n <= c.size {
+		ch, err := chunk.New(text, offset, offset+runes, n)
+		if err != nil {
+			return nil, err
+		}
+		return []chunk.Chunk{ch}, nil
+	}
+
+	if level >= len(c.rules) || c.rules[level].Token {
+		return c.hardSplit(text, offset)
+	}
+
+	rule := c.rules[level]
+	pieces, err := split.Text(text, split.Options{
+		Delimiters: rule.Delimiters,
+		Attach:     rule.Attach,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(pieces) <= 1 {
+		return c.chunkAt(text, level+1, offset)
+	}
+
+	var out []chunk.Chunk
+	for _, group := range pack(pieces, c.tok, c.size) {
+		gText, gTokens := joinGroup(group, c.tok)
+		gOffset := offset + group[0].Start
+		if gTokens <= c.size {
+			ch, err := chunk.New(gText, gOffset, offset+group[len(group)-1].End, gTokens)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, ch)
+			continue
+		}
+		more, err := c.chunkAt(gText, level+1, gOffset)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, more...)
+	}
+	return out, nil
+}
+
+func (c Chunker) hardSplit(text string, offset int) ([]chunk.Chunk, error) {
+	chunks, err := c.hard.Chunk(text)
+	if err != nil {
+		return nil, err
+	}
+	if offset == 0 {
+		return chunks, nil
+	}
+	out := make([]chunk.Chunk, len(chunks))
+	for i, ch := range chunks {
+		ch.Start += offset
+		ch.End += offset
+		out[i] = ch
+	}
+	return out, nil
+}
+
+func pack(pieces []split.Piece, tok tokenizer.Tokenizer, size int) [][]split.Piece {
+	var groups [][]split.Piece
+	buf := make([]split.Piece, 0, 4)
+	tokens := 0
+	flush := func() {
+		if len(buf) == 0 {
+			return
+		}
+		g := make([]split.Piece, len(buf))
+		copy(g, buf)
+		groups = append(groups, g)
+		buf = buf[:0]
+		tokens = 0
+	}
+	for _, p := range pieces {
+		n := tok.Count(p.Text)
+		if len(buf) > 0 && tokens+n > size {
+			flush()
+		}
+		buf = append(buf, p)
+		tokens += n
+	}
+	flush()
+	return groups
+}
+
+func joinGroup(group []split.Piece, tok tokenizer.Tokenizer) (string, int) {
+	var b strings.Builder
+	n := 0
+	for _, p := range group {
+		b.WriteString(p.Text)
+		n += tok.Count(p.Text)
+	}
+	return b.String(), n
+}

--- a/pkg/recursive/chunker_test.go
+++ b/pkg/recursive/chunker_test.go
@@ -1,0 +1,170 @@
+package recursive
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bluesky585/nibble/internal/assertchunk"
+	"github.com/bluesky585/nibble/pkg/split"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(nil, 8, nil)
+	if err == nil || !strings.Contains(err.Error(), "tokenizer is required") {
+		t.Fatalf("err=%v", err)
+	}
+	_, err = New(tokenizer.Character{}, 0, nil)
+	if err == nil || !strings.Contains(err.Error(), "size must be > 0") {
+		t.Fatalf("err=%v", err)
+	}
+	_, err = New(tokenizer.Character{}, 8, []Level{
+		{Token: true, Delimiters: []string{"."}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "token level cannot set delimiters") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestChunkShortText(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 64, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := "hello"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Text != original {
+		t.Fatalf("got %+v", got)
+	}
+	assertchunk.Split(t, original, got)
+}
+
+func TestChunkParagraphThenSentence(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 12, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "Hello. World.\n\nHi. There."
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+
+	// "Hello. World.\n\n" is 15 runes > 12, so it drops to sentences.
+	if len(got) < 2 {
+		t.Fatalf("expected recursion into sentences, got %+v", got)
+	}
+	if got[0].Text != "Hello." {
+		t.Fatalf("first=%q", got[0].Text)
+	}
+}
+
+func TestChunkTokenFallback(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 3, []Level{{Token: true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "abcdefgh"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if len(got) != 3 {
+		t.Fatalf("len=%d want 3", len(got))
+	}
+	if got[0].Text != "abc" || got[1].Text != "def" || got[2].Text != "gh" {
+		t.Fatalf("got %q %q %q", got[0].Text, got[1].Text, got[2].Text)
+	}
+}
+
+func TestChunkUnicode(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 3, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "你好。世界！"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if got[0].Text != "你好。" || got[1].Text != "世界！" {
+		t.Fatalf("got %+v", got)
+	}
+	if got[0].End != 3 || got[1].Start != 3 {
+		t.Fatalf("rune offsets %+v %+v", got[0], got[1])
+	}
+}
+
+func TestChunkSingleLevelDelimiters(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 4, []Level{
+		{Delimiters: []string{"."}, Attach: split.AttachPrev},
+		{Token: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "aa.bb.cc"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+}
+
+func TestChunkEmpty(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 8, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.Chunk("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, "", got)
+}
+
+func TestChunkNoDelimiterFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 3, []Level{
+		{Delimiters: []string{"."}, Attach: split.AttachPrev},
+		{Token: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "abcdefgh"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if got[0].Text != "abc" {
+		t.Fatalf("expected token fallback, got %+v", got)
+	}
+}

--- a/pkg/recursive/rules.go
+++ b/pkg/recursive/rules.go
@@ -1,0 +1,39 @@
+package recursive
+
+import (
+	"fmt"
+
+	"github.com/bluesky585/nibble/pkg/split"
+)
+
+// Level is one splitting pass. A token level ignores Delimiters and
+// hard-splits with the tokenizer.
+type Level struct {
+	Delimiters []string
+	Attach     split.Attach
+	Token      bool
+}
+
+func (l Level) validate() error {
+	if l.Token && len(l.Delimiters) > 0 {
+		return fmt.Errorf("token level cannot set delimiters")
+	}
+	for _, d := range l.Delimiters {
+		if d == "" {
+			return fmt.Errorf("delimiters must not be empty strings")
+		}
+	}
+	return nil
+}
+
+// DefaultRules split from coarse to fine: paragraphs, sentences,
+// clauses, whitespace, then tokens.
+func DefaultRules() []Level {
+	return []Level{
+		{Delimiters: []string{"\n\n", "\r\n", "\n", "\r"}, Attach: split.AttachPrev},
+		{Delimiters: []string{"。", "！", "？", ".", "!", "?"}, Attach: split.AttachPrev},
+		{Delimiters: []string{"，", "；", ",", ";", ":"}, Attach: split.AttachPrev},
+		{Delimiters: []string{" ", "\t"}, Attach: split.AttachPrev},
+		{Token: true},
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pkg/recursive`: split from coarse structure down to tokens.
- Default rules: paragraphs → sentences → clauses → spaces → token windows.
- Pieces that fit the token budget are emitted; oversized pieces recurse to the next level.
- Substring recursion shifts rune offsets so they remain absolute in the original text. No-overlap splits still reconstruct.

## Test plan
- [x] `go test ./...`
- [ ] `"Hello. World.\\n\\nHi. There."` with size 12: first chunk is `Hello.` (paragraph was too big).
- [ ] `"你好。世界！"` with size 3: two chunks, offsets 0-3 and 3-6.
- [ ] `"abcdefgh"` with a token-only rule and size 3: `abc` `def` `gh`.