### PR TITLE
Add a CLI that chunks a file and prints JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,20 @@ The name means a small bite: chunks should be small enough to retrieve on their 
 - **Small core.** Get chunking right first. Document parsing, embeddings, and vector stores are out of scope for now.
 - **English only.** Code, comments, commit messages, and docs in this repo are written in English.
 
-## Status
+## CLI
 
-The repo is newly initialized. There is no chunker yet. Next: types, tokenizer, delimiter splitting, then chunkers.
+```bash
+go run ./cmd/nibble -chunker recursive -size 512 path/to/file.txt
+```
+
+Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `-chunker` | `recursive` | `recursive`, `sentence`, or `token` |
+| `-tokenizer` | `character` | `character` or `word` |
+| `-size` | `512` | max tokens per chunk |
+| `-overlap` | `0` | token overlap; token chunker only |
 
 ## Development
 
@@ -23,6 +34,5 @@ Requires Go 1.26+.
 
 ```bash
 go test ./...
+go build -o nibble ./cmd/nibble
 ```
-
-There are no Go packages yet, so this command reports that no packages matched. That is expected.

--- a/cmd/nibble/main.go
+++ b/cmd/nibble/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/bluesky585/nibble/internal/cli"
+)
+
+func main() {
+	os.Exit(cli.Run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,125 @@
+// Package cli implements the nibble command: read text, chunk it, write JSON.
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/recursive"
+	"github.com/bluesky585/nibble/pkg/sentencechunker"
+	"github.com/bluesky585/nibble/pkg/tokenchunker"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+type chunker interface {
+	Chunk(text string) ([]chunk.Chunk, error)
+}
+
+// Run parses args, chunks input, and writes JSON chunks to stdout.
+// It returns a process exit code.
+func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("nibble", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, "Usage: nibble [flags] [file]\n")
+		fmt.Fprintf(stderr, "  Read a UTF-8 text file (or stdin) and print chunks as JSON.\n\n")
+		fs.PrintDefaults()
+	}
+
+	chunkerName := fs.String("chunker", "recursive", "chunker: recursive, sentence, or token")
+	tokName := fs.String("tokenizer", "character", "tokenizer: character or word")
+	size := fs.Int("size", 512, "max tokens per chunk")
+	overlap := fs.Int("overlap", 0, "token overlap (token chunker only)")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	text, err := readInput(fs.Args(), stdin)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+
+	c, err := newChunker(*chunkerName, *tokName, *size, *overlap)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+
+	chunks, err := c.Chunk(text)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if chunks == nil {
+		chunks = []chunk.Chunk{}
+	}
+
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(chunks); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func readInput(files []string, stdin io.Reader) (string, error) {
+	switch len(files) {
+	case 0:
+		b, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	case 1:
+		b, err := os.ReadFile(files[0])
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	default:
+		return "", fmt.Errorf("expected at most one file, got %s", strings.Join(files, ", "))
+	}
+}
+
+func newChunker(chunkerName, tokName string, size, overlap int) (chunker, error) {
+	tok, err := newTokenizer(tokName)
+	if err != nil {
+		return nil, err
+	}
+
+	switch chunkerName {
+	case "recursive":
+		if overlap != 0 {
+			return nil, fmt.Errorf("overlap is only supported by the token chunker")
+		}
+		return recursive.New(tok, size, nil)
+	case "sentence":
+		if overlap != 0 {
+			return nil, fmt.Errorf("overlap is only supported by the token chunker")
+		}
+		return sentencechunker.New(tok, size, nil)
+	case "token":
+		return tokenchunker.New(tok, size, overlap)
+	default:
+		return nil, fmt.Errorf("unknown chunker %q", chunkerName)
+	}
+}
+
+func newTokenizer(name string) (tokenizer.Tokenizer, error) {
+	switch name {
+	case "character":
+		return tokenizer.Character{}, nil
+	case "word":
+		return tokenizer.Word{}, nil
+	default:
+		return nil, fmt.Errorf("unknown tokenizer %q", name)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bluesky585/nibble/internal/assertchunk"
+	"github.com/bluesky585/nibble/pkg/chunk"
+)
+
+func TestRunStdin(t *testing.T) {
+	t.Parallel()
+
+	in := strings.NewReader("Hello. World.")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "sentence", "-size", "64"}, in, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+
+	var chunks []chunk.Chunk
+	if err := json.Unmarshal(stdout.Bytes(), &chunks); err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, "Hello. World.", chunks)
+}
+
+func TestRunFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.txt")
+	original := "你好。世界！"
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "recursive", "-size", "3", path}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+
+	var chunks []chunk.Chunk
+	if err := json.Unmarshal(stdout.Bytes(), &chunks); err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, chunks)
+	if chunks[0].End != 3 {
+		t.Fatalf("want rune offsets, first end=%d", chunks[0].End)
+	}
+}
+
+func TestRunTokenOverlap(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "token", "-size", "3", "-overlap", "1"}, strings.NewReader("hello"), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+
+	var chunks []chunk.Chunk
+	if err := json.Unmarshal(stdout.Bytes(), &chunks); err != nil {
+		t.Fatal(err)
+	}
+	if len(chunks) != 2 || chunks[0].Text != "hel" || chunks[1].Text != "llo" {
+		t.Fatalf("got %+v", chunks)
+	}
+}
+
+func TestRunOverlapRejected(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "recursive", "-overlap", "1"}, strings.NewReader("hi"), &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit %d want 2 stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "overlap is only supported by the token chunker") {
+		t.Fatalf("stderr=%s", stderr.String())
+	}
+}
+
+func TestRunUnknownChunker(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "magic"}, strings.NewReader("hi"), &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit %d want 2", code)
+	}
+}
+
+func TestRunTooManyFiles(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"a.txt", "b.txt"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit %d want 1 stderr=%s", code, stderr.String())
+	}
+}
+
+func TestRunEmpty(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Run(nil, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "[]" {
+		t.Fatalf("stdout=%s", stdout.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Add `cmd/nibble`: read a UTF-8 file or stdin, chunk it, print JSON.
- Flags: `-chunker` (`recursive` / `sentence` / `token`), `-tokenizer`, `-size`, `-overlap`.
- Overlap is rejected unless the token chunker is selected.
- `internal/cli.Run` is the testable entry point (stdin/stdout/stderr injected).

## Test plan
- [x] `go test ./...`
- [ ] `go run ./cmd/nibble -chunker sentence -size 64` with stdin `Hello. World.`
- [ ] Recursive on `你好。世界！` with `-size 3` uses rune offsets (first `end` is 3).