### PR TITLE
Add an HTTP API for chunking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin/
 dist/
 /nibble
+/nibble-api
 *.exe
 *.exe~
 *.dll

--- a/README.md
+++ b/README.md
@@ -28,6 +28,31 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 | `-size` | `512` | max tokens per chunk |
 | `-overlap` | `0` | token overlap; token chunker only |
 
+## HTTP API
+
+```bash
+go run ./cmd/nibble-api -addr 127.0.0.1:8080
+```
+
+| Method | Path | Meaning |
+| --- | --- | --- |
+| `GET` | `/health` | liveness |
+| `POST` | `/v1/chunk` | chunk JSON body |
+
+`POST /v1/chunk` body:
+
+```json
+{
+  "text": "Hello. World.",
+  "chunker": "recursive",
+  "tokenizer": "character",
+  "size": 512,
+  "overlap": 0
+}
+```
+
+Omitted fields use the same defaults as the CLI. Response: `{"chunks":[...]}`.
+
 ## Development
 
 Requires Go 1.26+.
@@ -35,4 +60,5 @@ Requires Go 1.26+.
 ```bash
 go test ./...
 go build -o nibble ./cmd/nibble
+go build -o nibble-api ./cmd/nibble-api
 ```

--- a/cmd/nibble-api/main.go
+++ b/cmd/nibble-api/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+
+	"github.com/bluesky585/nibble/internal/httpapi"
+)
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:8080", "listen address")
+	flag.Parse()
+
+	log.Printf("nibble-api listening on %s", *addr)
+	if err := http.ListenAndServe(*addr, httpapi.Handler()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/buildchunk/build.go
+++ b/internal/buildchunk/build.go
@@ -1,0 +1,53 @@
+// Package buildchunk constructs a chunker from CLI or API options.
+package buildchunk
+
+import (
+	"fmt"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/recursive"
+	"github.com/bluesky585/nibble/pkg/sentencechunker"
+	"github.com/bluesky585/nibble/pkg/tokenchunker"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+// Chunker splits text into chunks.
+type Chunker interface {
+	Chunk(text string) ([]chunk.Chunk, error)
+}
+
+// New builds a chunker. overlap is valid only for the token chunker.
+func New(chunkerName, tokName string, size, overlap int) (Chunker, error) {
+	tok, err := newTokenizer(tokName)
+	if err != nil {
+		return nil, err
+	}
+
+	switch chunkerName {
+	case "recursive":
+		if overlap != 0 {
+			return nil, fmt.Errorf("overlap is only supported by the token chunker")
+		}
+		return recursive.New(tok, size, nil)
+	case "sentence":
+		if overlap != 0 {
+			return nil, fmt.Errorf("overlap is only supported by the token chunker")
+		}
+		return sentencechunker.New(tok, size, nil)
+	case "token":
+		return tokenchunker.New(tok, size, overlap)
+	default:
+		return nil, fmt.Errorf("unknown chunker %q", chunkerName)
+	}
+}
+
+func newTokenizer(name string) (tokenizer.Tokenizer, error) {
+	switch name {
+	case "character":
+		return tokenizer.Character{}, nil
+	case "word":
+		return tokenizer.Word{}, nil
+	default:
+		return nil, fmt.Errorf("unknown tokenizer %q", name)
+	}
+}

--- a/internal/buildchunk/build_test.go
+++ b/internal/buildchunk/build_test.go
@@ -1,0 +1,45 @@
+package buildchunk
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bluesky585/nibble/internal/assertchunk"
+)
+
+func TestNewRecursive(t *testing.T) {
+	t.Parallel()
+
+	c, err := New("recursive", "character", 64, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := "Hello. World."
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+}
+
+func TestNewOverlapRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := New("sentence", "character", 64, 1)
+	if err == nil || !strings.Contains(err.Error(), "overlap is only supported by the token chunker") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestNewUnknown(t *testing.T) {
+	t.Parallel()
+
+	_, err := New("magic", "character", 8, 0)
+	if err == nil || !strings.Contains(err.Error(), "unknown chunker") {
+		t.Fatalf("err=%v", err)
+	}
+	_, err = New("token", "emoji", 8, 0)
+	if err == nil || !strings.Contains(err.Error(), "unknown tokenizer") {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -9,16 +9,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/bluesky585/nibble/internal/buildchunk"
 	"github.com/bluesky585/nibble/pkg/chunk"
-	"github.com/bluesky585/nibble/pkg/recursive"
-	"github.com/bluesky585/nibble/pkg/sentencechunker"
-	"github.com/bluesky585/nibble/pkg/tokenchunker"
-	"github.com/bluesky585/nibble/pkg/tokenizer"
 )
-
-type chunker interface {
-	Chunk(text string) ([]chunk.Chunk, error)
-}
 
 // Run parses args, chunks input, and writes JSON chunks to stdout.
 // It returns a process exit code.
@@ -46,7 +39,7 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	c, err := newChunker(*chunkerName, *tokName, *size, *overlap)
+	c, err := buildchunk.New(*chunkerName, *tokName, *size, *overlap)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 2
@@ -86,40 +79,5 @@ func readInput(files []string, stdin io.Reader) (string, error) {
 		return string(b), nil
 	default:
 		return "", fmt.Errorf("expected at most one file, got %s", strings.Join(files, ", "))
-	}
-}
-
-func newChunker(chunkerName, tokName string, size, overlap int) (chunker, error) {
-	tok, err := newTokenizer(tokName)
-	if err != nil {
-		return nil, err
-	}
-
-	switch chunkerName {
-	case "recursive":
-		if overlap != 0 {
-			return nil, fmt.Errorf("overlap is only supported by the token chunker")
-		}
-		return recursive.New(tok, size, nil)
-	case "sentence":
-		if overlap != 0 {
-			return nil, fmt.Errorf("overlap is only supported by the token chunker")
-		}
-		return sentencechunker.New(tok, size, nil)
-	case "token":
-		return tokenchunker.New(tok, size, overlap)
-	default:
-		return nil, fmt.Errorf("unknown chunker %q", chunkerName)
-	}
-}
-
-func newTokenizer(name string) (tokenizer.Tokenizer, error) {
-	switch name {
-	case "character":
-		return tokenizer.Character{}, nil
-	case "word":
-		return tokenizer.Word{}, nil
-	default:
-		return nil, fmt.Errorf("unknown tokenizer %q", name)
 	}
 }

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -1,0 +1,86 @@
+// Package httpapi serves chunking over HTTP.
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/bluesky585/nibble/internal/buildchunk"
+	"github.com/bluesky585/nibble/pkg/chunk"
+)
+
+const maxBody = 10 << 20
+
+// Handler is the HTTP API.
+func Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", health)
+	mux.HandleFunc("POST /v1/chunk", chunkText)
+	return mux
+}
+
+func health(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+type chunkRequest struct {
+	Text      string `json:"text"`
+	Chunker   string `json:"chunker"`
+	Tokenizer string `json:"tokenizer"`
+	Size      int    `json:"size"`
+	Overlap   int    `json:"overlap"`
+}
+
+type chunkResponse struct {
+	Chunks []chunk.Chunk `json:"chunks"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+func chunkText(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBody)
+
+	var req chunkRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+		return
+	}
+
+	if req.Chunker == "" {
+		req.Chunker = "recursive"
+	}
+	if req.Tokenizer == "" {
+		req.Tokenizer = "character"
+	}
+	if req.Size == 0 {
+		req.Size = 512
+	}
+
+	c, err := buildchunk.New(req.Chunker, req.Tokenizer, req.Size, req.Overlap)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+		return
+	}
+
+	chunks, err := c.Chunk(req.Text)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: err.Error()})
+		return
+	}
+	if chunks == nil {
+		chunks = []chunk.Chunk{}
+	}
+	writeJSON(w, http.StatusOK, chunkResponse{Chunks: chunks})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -1,0 +1,151 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bluesky585/nibble/internal/assertchunk"
+)
+
+func TestHealth(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"ok": true`) {
+		t.Fatalf("body=%s", rec.Body.String())
+	}
+}
+
+func TestChunkOK(t *testing.T) {
+	t.Parallel()
+
+	body := `{"text":"Hello. World.","chunker":"sentence","size":64}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chunk", strings.NewReader(body))
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp chunkResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, "Hello. World.", resp.Chunks)
+}
+
+func TestChunkUnicodeDefaults(t *testing.T) {
+	t.Parallel()
+
+	original := "你好。世界！"
+	raw, _ := json.Marshal(chunkRequest{Text: original, Size: 3})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chunk", bytes.NewReader(raw))
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp chunkResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, resp.Chunks)
+	if resp.Chunks[0].End != 3 {
+		t.Fatalf("want rune offset 3, got %+v", resp.Chunks[0])
+	}
+}
+
+func TestChunkEmpty(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chunk", strings.NewReader(`{"text":""}`))
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp chunkResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Chunks == nil {
+		t.Fatal("chunks should be empty list, not null")
+	}
+	assertchunk.Split(t, "", resp.Chunks)
+}
+
+func TestChunkBadOptions(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chunk", strings.NewReader(`{"text":"hi","chunker":"magic"}`))
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", rec.Code)
+	}
+}
+
+func TestChunkOverlapRejected(t *testing.T) {
+	t.Parallel()
+
+	body := `{"text":"hi","chunker":"recursive","overlap":1}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chunk", strings.NewReader(body))
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestChunkMethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/chunk", nil)
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status %d", rec.Code)
+	}
+}
+
+func TestTokenOverlap(t *testing.T) {
+	t.Parallel()
+
+	body := `{"text":"hello","chunker":"token","size":3,"overlap":1}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chunk", strings.NewReader(body))
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp chunkResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Chunks) != 2 || resp.Chunks[0].Text != "hel" || resp.Chunks[1].Text != "llo" {
+		t.Fatalf("got %+v", resp.Chunks)
+	}
+}
+
+func TestUnknownField(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chunk", strings.NewReader(`{"text":"hi","nope":1}`))
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- Extract `internal/buildchunk` so CLI and API construct chunkers the same way.
- Add `POST /v1/chunk` and `GET /health` in `internal/httpapi`.
- Add `cmd/nibble-api` (`-addr`, default `127.0.0.1:8080`).
- Handler tests use `httptest`; nothing listens on a real port in CI.

## Test plan
- [x] `go test ./...`
- [ ] After merge, start locally if you want: `go run ./cmd/nibble-api`
- [ ] `curl -sS http://127.0.0.1:8080/health`
- [ ] `POST /v1/chunk` with `{"text":"你好。世界！","size":3}` — first chunk `end` is 3.