### PR TITLE
Add a fast byte-budget chunker

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 
 | Flag | Default | Meaning |
 | --- | --- | --- |
-| `-chunker` | `recursive` | `recursive`, `sentence`, or `token` |
-| `-tokenizer` | `character` | `character` or `word` |
-| `-size` | `512` | max tokens per chunk |
+| `-chunker` | `recursive` | `recursive`, `sentence`, `token`, or `fast` |
+| `-tokenizer` | `character` | `character` or `word` (ignored by `fast`) |
+| `-size` | `512` | max tokens per chunk; **max bytes** for `fast` |
 | `-overlap` | `0` | token overlap; token chunker only |
+
+`fast` looks for a delimiter near the byte budget and never splits a UTF-8 rune. JSON `start`/`end` are still rune offsets.
 
 ## HTTP API
 

--- a/internal/buildchunk/build.go
+++ b/internal/buildchunk/build.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/fastchunker"
 	"github.com/bluesky585/nibble/pkg/recursive"
 	"github.com/bluesky585/nibble/pkg/sentencechunker"
 	"github.com/bluesky585/nibble/pkg/tokenchunker"
@@ -17,7 +18,16 @@ type Chunker interface {
 }
 
 // New builds a chunker. overlap is valid only for the token chunker.
+// The tokenizer is ignored when chunkerName is "fast"; size is then a
+// byte budget, while chunk offsets remain runes.
 func New(chunkerName, tokName string, size, overlap int) (Chunker, error) {
+	if chunkerName == "fast" {
+		if overlap != 0 {
+			return nil, fmt.Errorf("overlap is only supported by the token chunker")
+		}
+		return fastchunker.New(size, nil)
+	}
+
 	tok, err := newTokenizer(tokName)
 	if err != nil {
 		return nil, err

--- a/internal/buildchunk/build_test.go
+++ b/internal/buildchunk/build_test.go
@@ -31,6 +31,21 @@ func TestNewOverlapRejected(t *testing.T) {
 	}
 }
 
+func TestNewFast(t *testing.T) {
+	t.Parallel()
+
+	c, err := New("fast", "character", 8, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := "hello world"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+}
+
 func TestNewUnknown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,9 +24,9 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		fs.PrintDefaults()
 	}
 
-	chunkerName := fs.String("chunker", "recursive", "chunker: recursive, sentence, or token")
-	tokName := fs.String("tokenizer", "character", "tokenizer: character or word")
-	size := fs.Int("size", 512, "max tokens per chunk")
+	chunkerName := fs.String("chunker", "recursive", "chunker: recursive, sentence, token, or fast")
+	tokName := fs.String("tokenizer", "character", "tokenizer: character or word (ignored by fast)")
+	size := fs.Int("size", 512, "max tokens per chunk (max bytes for fast)")
 	overlap := fs.Int("overlap", 0, "token overlap (token chunker only)")
 
 	if err := fs.Parse(args); err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -55,6 +55,26 @@ func TestRunFile(t *testing.T) {
 	}
 }
 
+func TestRunFast(t *testing.T) {
+	t.Parallel()
+
+	original := "你好"
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "fast", "-size", "1"}, strings.NewReader(original), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+
+	var chunks []chunk.Chunk
+	if err := json.Unmarshal(stdout.Bytes(), &chunks); err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, chunks)
+	if chunks[0].End != 1 {
+		t.Fatalf("want rune end 1, got %+v", chunks[0])
+	}
+}
+
 func TestRunTokenOverlap(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/fastchunker/chunker.go
+++ b/pkg/fastchunker/chunker.go
@@ -1,0 +1,101 @@
+// Package fastchunker splits text by a byte budget, preferring delimiter
+// boundaries. Chunk offsets are still rune indexes.
+package fastchunker
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+)
+
+// DefaultDelimiters are tried from the end of a byte window. Longer
+// matches that end later win.
+var DefaultDelimiters = []string{
+	"\n\n", "\r\n", "\n", "\r",
+	"。", "！", "？",
+	". ", "? ", "! ",
+	".", "?", "!",
+	" ", "\t",
+}
+
+// Chunker cuts text into windows of at most Size bytes, except a single
+// rune that is longer than Size is kept whole so UTF-8 is never split.
+type Chunker struct {
+	size   int
+	delims []string
+}
+
+// New builds a Chunker. Empty delims use DefaultDelimiters.
+func New(size int, delims []string) (Chunker, error) {
+	if size <= 0 {
+		return Chunker{}, fmt.Errorf("size must be > 0, got %d", size)
+	}
+	for _, d := range delims {
+		if d == "" {
+			return Chunker{}, fmt.Errorf("delimiters must not be empty strings")
+		}
+	}
+	if len(delims) == 0 {
+		delims = append([]string(nil), DefaultDelimiters...)
+	} else {
+		delims = append([]string(nil), delims...)
+	}
+	return Chunker{size: size, delims: delims}, nil
+}
+
+// Chunk splits text. Size is a byte budget; Start/End are rune offsets.
+func (c Chunker) Chunk(text string) ([]chunk.Chunk, error) {
+	if text == "" {
+		return nil, nil
+	}
+
+	var out []chunk.Chunk
+	runeStart := 0
+	for start := 0; start < len(text); {
+		end := c.cutEnd(text, start)
+		piece := text[start:end]
+		n := utf8.RuneCountInString(piece)
+		ch, err := chunk.New(piece, runeStart, runeStart+n, n)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ch)
+		runeStart += n
+		start = end
+	}
+	return out, nil
+}
+
+func (c Chunker) cutEnd(text string, start int) int {
+	if start+c.size >= len(text) {
+		return len(text)
+	}
+
+	end := start + c.size
+	for end > start && !utf8.RuneStart(text[end]) {
+		end--
+	}
+	if end == start {
+		_, w := utf8.DecodeRuneInString(text[start:])
+		return start + w
+	}
+
+	window := text[start:end]
+	best := -1
+	for _, d := range c.delims {
+		idx := strings.LastIndex(window, d)
+		if idx < 0 {
+			continue
+		}
+		cut := start + idx + len(d)
+		if cut > start && cut <= end && cut > best {
+			best = cut
+		}
+	}
+	if best > start {
+		return best
+	}
+	return end
+}

--- a/pkg/fastchunker/chunker_test.go
+++ b/pkg/fastchunker/chunker_test.go
@@ -1,0 +1,133 @@
+package fastchunker
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/bluesky585/nibble/internal/assertchunk"
+)
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(0, nil)
+	if err == nil || !strings.Contains(err.Error(), "size must be > 0") {
+		t.Fatalf("err=%v", err)
+	}
+	_, err = New(8, []string{""})
+	if err == nil || !strings.Contains(err.Error(), "delimiters must not be empty") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestChunkPrefersDelimiter(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(8, []string{" "})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "hello world"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if len(got) != 2 || got[0].Text != "hello " || got[1].Text != "world" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestChunkHardCutNoDelim(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(3, []string{" "})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "abcdefgh"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if got[0].Text != "abc" || got[1].Text != "def" || got[2].Text != "gh" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestChunkDoesNotSplitRune(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(1, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "你好"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if len(got) != 2 || got[0].Text != "你" || got[1].Text != "好" {
+		t.Fatalf("got %+v", got)
+	}
+	if got[0].Start != 0 || got[0].End != 1 || got[1].End != 2 {
+		t.Fatalf("rune offsets %+v %+v (not bytes; 你 is 3 bytes)", got[0], got[1])
+	}
+	if utf8.RuneCountInString(original) != 2 || len(original) != 6 {
+		t.Fatal("precondition")
+	}
+}
+
+func TestChunkNewline(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(20, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "first line\n\nsecond"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+}
+
+func TestChunkEmpty(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(8, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.Chunk("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, "", got)
+}
+
+func TestChunkShorterThanSize(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(64, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := "hi"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Text != original {
+		t.Fatalf("got %+v", got)
+	}
+	assertchunk.Split(t, original, got)
+}


### PR DESCRIPTION
## Summary
- Add `pkg/fastchunker`: split by a **byte** budget, prefer a delimiter near the cut, never split a UTF-8 rune.
- `Chunk.Start` / `End` are still **rune** offsets. No-overlap splits still reconstruct.
- CLI/API: `-chunker fast`. `-size` is max bytes. Tokenizer is ignored. Overlap is rejected.

## Test plan
- [x] `go test ./...`
- [ ] `"hello world"` with size 8 and space delimiter → `hello ` then `world`.
- [ ] `"你好"` with size 1 → two chunks; first `end` is 1 (not 3 bytes).