### PR TITLE
Add a Markdown table chunker with header context

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 
 | Flag | Default | Meaning |
 | --- | --- | --- |
-| `-chunker` | `recursive` | `recursive`, `sentence`, `token`, or `fast` |
+| `-chunker` | `recursive` | `recursive`, `sentence`, `token`, `fast`, or `table` |
 | `-tokenizer` | `character` | `character` or `word` (ignored by `fast`) |
 | `-size` | `512` | max tokens per chunk; **max bytes** for `fast` |
 | `-overlap` | `0` | token overlap; token chunker only |
 
 `fast` looks for a delimiter near the byte budget and never splits a UTF-8 rune. JSON `start`/`end` are still rune offsets.
+
+`table` splits GitHub-flavored Markdown tables by row. Later row-groups copy the header into `context` so retrieval keeps column names; `text` stays a slice of the original, so reconstruct still works.
 
 ## HTTP API
 

--- a/internal/buildchunk/build.go
+++ b/internal/buildchunk/build.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bluesky585/nibble/pkg/fastchunker"
 	"github.com/bluesky585/nibble/pkg/recursive"
 	"github.com/bluesky585/nibble/pkg/sentencechunker"
+	"github.com/bluesky585/nibble/pkg/tablechunker"
 	"github.com/bluesky585/nibble/pkg/tokenchunker"
 	"github.com/bluesky585/nibble/pkg/tokenizer"
 )
@@ -46,6 +47,11 @@ func New(chunkerName, tokName string, size, overlap int) (Chunker, error) {
 		return sentencechunker.New(tok, size, nil)
 	case "token":
 		return tokenchunker.New(tok, size, overlap)
+	case "table":
+		if overlap != 0 {
+			return nil, fmt.Errorf("overlap is only supported by the token chunker")
+		}
+		return tablechunker.New(tok, size)
 	default:
 		return nil, fmt.Errorf("unknown chunker %q", chunkerName)
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,7 +24,7 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		fs.PrintDefaults()
 	}
 
-	chunkerName := fs.String("chunker", "recursive", "chunker: recursive, sentence, token, or fast")
+	chunkerName := fs.String("chunker", "recursive", "chunker: recursive, sentence, token, fast, or table")
 	tokName := fs.String("tokenizer", "character", "tokenizer: character or word (ignored by fast)")
 	size := fs.Int("size", 512, "max tokens per chunk (max bytes for fast)")
 	overlap := fs.Int("overlap", 0, "token overlap (token chunker only)")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -55,6 +55,23 @@ func TestRunFile(t *testing.T) {
 	}
 }
 
+func TestRunTable(t *testing.T) {
+	t.Parallel()
+
+	original := "| h |\n| --- |\n| 1 |\n"
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "table", "-size", "64"}, strings.NewReader(original), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+
+	var chunks []chunk.Chunk
+	if err := json.Unmarshal(stdout.Bytes(), &chunks); err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, chunks)
+}
+
 func TestRunFast(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -16,6 +16,9 @@ type Chunk struct {
 	Start      int    `json:"start"`
 	End        int    `json:"end"`
 	TokenCount int    `json:"token_count"`
+	// Context is extra text for retrieval (for example a table header).
+	// It is not part of Text and is ignored by reconstruct checks.
+	Context string `json:"context,omitempty"`
 }
 
 // New builds a Chunk and checks its invariants.

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -100,6 +100,7 @@ func TestChunkJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	c.Context = "header"
 
 	raw, err := json.Marshal(c)
 	if err != nil {

--- a/pkg/tablechunker/chunker.go
+++ b/pkg/tablechunker/chunker.go
@@ -1,0 +1,228 @@
+// Package tablechunker splits Markdown tables by row while keeping the
+// header available on later chunks as Context.
+package tablechunker
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/tokenchunker"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+type line struct {
+	Text  string
+	Start int
+	End   int
+}
+
+// Chunker splits Markdown tables by rows. Non-table text is packed with
+// the token chunker when it exceeds Size.
+type Chunker struct {
+	tok  tokenizer.Tokenizer
+	size int
+	hard tokenchunker.Chunker
+}
+
+// New builds a Chunker.
+func New(tok tokenizer.Tokenizer, size int) (Chunker, error) {
+	if tok == nil {
+		return Chunker{}, fmt.Errorf("tokenizer is required")
+	}
+	if size <= 0 {
+		return Chunker{}, fmt.Errorf("size must be > 0, got %d", size)
+	}
+	hard, err := tokenchunker.New(tok, size, 0)
+	if err != nil {
+		return Chunker{}, err
+	}
+	return Chunker{tok: tok, size: size, hard: hard}, nil
+}
+
+// Chunk splits text. Table continuation chunks copy the header into Context.
+func (c Chunker) Chunk(text string) ([]chunk.Chunk, error) {
+	lines := splitLines(text)
+	if len(lines) == 0 {
+		return nil, nil
+	}
+
+	var out []chunk.Chunk
+	for i := 0; i < len(lines); {
+		if isTableStart(lines, i) {
+			end := tableEnd(lines, i)
+			chunks, err := c.chunkTable(lines[i:end])
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, chunks...)
+			i = end
+			continue
+		}
+		end := i + 1
+		for end < len(lines) && !isTableStart(lines, end) {
+			end++
+		}
+		chunks, err := c.chunkProse(lines[i:end])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, chunks...)
+		i = end
+	}
+	return out, nil
+}
+
+func (c Chunker) chunkProse(lines []line) ([]chunk.Chunk, error) {
+	text := join(lines)
+	n := c.tok.Count(text)
+	if n <= c.size {
+		ch, err := chunk.New(text, lines[0].Start, lines[len(lines)-1].End, n)
+		if err != nil {
+			return nil, err
+		}
+		return []chunk.Chunk{ch}, nil
+	}
+	chunks, err := c.hard.Chunk(text)
+	if err != nil {
+		return nil, err
+	}
+	offset := lines[0].Start
+	if offset == 0 {
+		return chunks, nil
+	}
+	out := make([]chunk.Chunk, len(chunks))
+	for i, ch := range chunks {
+		ch.Start += offset
+		ch.End += offset
+		out[i] = ch
+	}
+	return out, nil
+}
+
+func (c Chunker) chunkTable(lines []line) ([]chunk.Chunk, error) {
+	header := []line{lines[0], lines[1]}
+	headerText := join(header)
+	rows := lines[2:]
+
+	var out []chunk.Chunk
+	flush := func(group []line, withHeader bool) error {
+		if len(group) == 0 {
+			return nil
+		}
+		text := join(group)
+		ch, err := chunk.New(text, group[0].Start, group[len(group)-1].End, c.tok.Count(text))
+		if err != nil {
+			return err
+		}
+		if !withHeader {
+			ch.Context = headerText
+		}
+		out = append(out, ch)
+		return nil
+	}
+
+	if len(rows) == 0 {
+		if err := flush(header, true); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+
+	group := append([]line(nil), header...)
+	tokens := c.tok.Count(headerText)
+	first := true
+	for _, row := range rows {
+		n := c.tok.Count(row.Text)
+		if len(group) > 0 && tokens+n > c.size && (!first || len(group) > len(header)) {
+			if err := flush(group, first); err != nil {
+				return nil, err
+			}
+			group = nil
+			tokens = 0
+			first = false
+		}
+		if first && len(group) == len(header) && tokens+n > c.size {
+			if err := flush(group, true); err != nil {
+				return nil, err
+			}
+			group = []line{row}
+			tokens = n
+			first = false
+			continue
+		}
+		group = append(group, row)
+		tokens += n
+	}
+	if err := flush(group, first); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func splitLines(text string) []line {
+	if text == "" {
+		return nil
+	}
+	var out []line
+	startB, startR := 0, 0
+	b, r := 0, 0
+	for b < len(text) {
+		if text[b] == '\n' {
+			endB := b + 1
+			endR := r + 1
+			out = append(out, line{Text: text[startB:endB], Start: startR, End: endR})
+			startB, startR = endB, endR
+			b, r = endB, endR
+			continue
+		}
+		_, w := utf8.DecodeRuneInString(text[b:])
+		b += w
+		r++
+	}
+	if startB < len(text) {
+		out = append(out, line{Text: text[startB:], Start: startR, End: r})
+	}
+	return out
+}
+
+func join(lines []line) string {
+	var b strings.Builder
+	for _, l := range lines {
+		b.WriteString(l.Text)
+	}
+	return b.String()
+}
+
+func isTableStart(lines []line, i int) bool {
+	return i+1 < len(lines) && isPipeRow(lines[i].Text) && isSeparator(lines[i+1].Text)
+}
+
+func tableEnd(lines []line, i int) int {
+	j := i + 2
+	for j < len(lines) && isPipeRow(lines[j].Text) {
+		j++
+	}
+	return j
+}
+
+func isPipeRow(s string) bool {
+	t := strings.TrimSpace(s)
+	return strings.HasPrefix(t, "|") && strings.Count(t, "|") >= 2
+}
+
+func isSeparator(s string) bool {
+	t := strings.TrimSpace(s)
+	if !strings.Contains(t, "|") || !strings.Contains(t, "-") {
+		return false
+	}
+	for _, r := range t {
+		switch r {
+		case '|', '-', ':', ' ', '\t', '\n', '\r':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/tablechunker/chunker_test.go
+++ b/pkg/tablechunker/chunker_test.go
@@ -1,0 +1,153 @@
+package tablechunker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bluesky585/nibble/internal/assertchunk"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(nil, 8)
+	if err == nil || !strings.Contains(err.Error(), "tokenizer is required") {
+		t.Fatalf("err=%v", err)
+	}
+	_, err = New(tokenizer.Character{}, 0)
+	if err == nil || !strings.Contains(err.Error(), "size must be > 0") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestChunkSmallTable(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "| h |\n| --- |\n| 1 |\n| 2 |\n"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if len(got) != 1 {
+		t.Fatalf("len=%d want 1", len(got))
+	}
+	if got[0].Context != "" {
+		t.Fatalf("single chunk should not copy header: %q", got[0].Context)
+	}
+}
+
+func TestChunkRepeatsHeaderInContext(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 18)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "| h |\n| --- |\n| 1 |\n| 2 |\n"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if len(got) < 2 {
+		t.Fatalf("expected a split table, got %+v", got)
+	}
+	if !strings.HasPrefix(got[0].Text, "| h |") {
+		t.Fatalf("first=%q", got[0].Text)
+	}
+	if got[len(got)-1].Context == "" {
+		t.Fatal("continuation chunk needs header context")
+	}
+	if !strings.Contains(got[len(got)-1].Context, "| h |") {
+		t.Fatalf("context=%q", got[len(got)-1].Context)
+	}
+	if strings.Contains(got[len(got)-1].Text, "| h |") {
+		t.Fatalf("continuation text should not repeat header: %q", got[len(got)-1].Text)
+	}
+}
+
+func TestChunkProseAndTable(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "intro\n\n| h |\n| --- |\n| 1 |\n\noutro\n"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if len(got) != 3 {
+		t.Fatalf("len=%d want 3 (prose, table, prose), got %+v", len(got), got)
+	}
+}
+
+func TestChunkUnicode(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "| 列 |\n| --- |\n| 值 |\n"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if got[0].End != runeCount(original) {
+		t.Fatalf("end=%d want %d", got[0].End, runeCount(original))
+	}
+}
+
+func TestChunkEmpty(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.Chunk("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, "", got)
+}
+
+func TestChunkOversizedProse(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := "abcdefgh"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if got[0].Text != "abc" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func runeCount(s string) int {
+	n := 0
+	for range s {
+		n++
+	}
+	return n
+}


### PR DESCRIPTION
## Summary
- Add optional `Chunk.Context` (not part of reconstruct).
- Add `tablechunker`: GFM tables split by row. The first chunk includes the header; later chunks put the header in `context` and keep `text` as the original rows.
- Prose around tables stays reconstructable; oversized prose uses the token chunker.
- CLI/API: `-chunker table`.

## Test plan
- [x] `go test ./...`
- [ ] A table that exceeds `-size` should still concatenate back to the original.
- [ ] Continuation chunks have `context` containing the header, and `text` does not.