### PR TITLE
Add a Go source chunker using go/parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 
 | Flag | Default | Meaning |
 | --- | --- | --- |
-| `-chunker` | `recursive` | `recursive`, `sentence`, `token`, `fast`, or `table` |
+| `-chunker` | `recursive` | `recursive`, `sentence`, `token`, `fast`, `table`, or `code` |
 | `-tokenizer` | `character` | `character` or `word` (ignored by `fast`) |
 | `-size` | `512` | max tokens per chunk; **max bytes** for `fast` |
 | `-overlap` | `0` | token overlap; token chunker only |
@@ -31,6 +31,8 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 `fast` looks for a delimiter near the byte budget and never splits a UTF-8 rune. JSON `start`/`end` are still rune offsets.
 
 `table` splits GitHub-flavored Markdown tables by row. Later row-groups copy the header into `context` so retrieval keeps column names; `text` stays a slice of the original, so reconstruct still works.
+
+`code` splits Go source on top-level declarations (package, types, funcs), keeping doc comments with the decl. If the file does not parse, it falls back to token windows.
 
 ## HTTP API
 

--- a/internal/buildchunk/build.go
+++ b/internal/buildchunk/build.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/codechunker"
 	"github.com/bluesky585/nibble/pkg/fastchunker"
 	"github.com/bluesky585/nibble/pkg/recursive"
 	"github.com/bluesky585/nibble/pkg/sentencechunker"
@@ -52,6 +53,11 @@ func New(chunkerName, tokName string, size, overlap int) (Chunker, error) {
 			return nil, fmt.Errorf("overlap is only supported by the token chunker")
 		}
 		return tablechunker.New(tok, size)
+	case "code":
+		if overlap != 0 {
+			return nil, fmt.Errorf("overlap is only supported by the token chunker")
+		}
+		return codechunker.New(tok, size)
 	default:
 		return nil, fmt.Errorf("unknown chunker %q", chunkerName)
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,7 +24,7 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		fs.PrintDefaults()
 	}
 
-	chunkerName := fs.String("chunker", "recursive", "chunker: recursive, sentence, token, fast, or table")
+	chunkerName := fs.String("chunker", "recursive", "chunker: recursive, sentence, token, fast, table, or code")
 	tokName := fs.String("tokenizer", "character", "tokenizer: character or word (ignored by fast)")
 	size := fs.Int("size", 512, "max tokens per chunk (max bytes for fast)")
 	overlap := fs.Int("overlap", 0, "token overlap (token chunker only)")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -55,6 +55,23 @@ func TestRunFile(t *testing.T) {
 	}
 }
 
+func TestRunCode(t *testing.T) {
+	t.Parallel()
+
+	original := "package p\n\nfunc A() {}\n"
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "code", "-size", "64"}, strings.NewReader(original), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+
+	var chunks []chunk.Chunk
+	if err := json.Unmarshal(stdout.Bytes(), &chunks); err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, chunks)
+}
+
 func TestRunTable(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/codechunker/chunker.go
+++ b/pkg/codechunker/chunker.go
@@ -1,0 +1,179 @@
+// Package codechunker splits Go source on top-level declarations.
+package codechunker
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/tokenchunker"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+// Chunker splits a Go file into declaration-sized windows.
+// Source that does not parse falls back to token windows.
+type Chunker struct {
+	tok  tokenizer.Tokenizer
+	size int
+	hard tokenchunker.Chunker
+}
+
+// New builds a Chunker.
+func New(tok tokenizer.Tokenizer, size int) (Chunker, error) {
+	if tok == nil {
+		return Chunker{}, fmt.Errorf("tokenizer is required")
+	}
+	if size <= 0 {
+		return Chunker{}, fmt.Errorf("size must be > 0, got %d", size)
+	}
+	hard, err := tokenchunker.New(tok, size, 0)
+	if err != nil {
+		return Chunker{}, err
+	}
+	return Chunker{tok: tok, size: size, hard: hard}, nil
+}
+
+// Chunk splits Go source. Offsets are rune indexes into text.
+func (c Chunker) Chunk(text string) ([]chunk.Chunk, error) {
+	if text == "" {
+		return nil, nil
+	}
+
+	pieces := c.declPieces(text)
+	if len(pieces) == 0 {
+		return c.hardSplit(text, 0)
+	}
+
+	var out []chunk.Chunk
+	var buf []piece
+	tokens := 0
+	flush := func() error {
+		if len(buf) == 0 {
+			return nil
+		}
+		var b strings.Builder
+		n := 0
+		for _, p := range buf {
+			b.WriteString(p.Text)
+			n += c.tok.Count(p.Text)
+		}
+		joined := b.String()
+		start := buf[0].Start
+		end := buf[len(buf)-1].End
+		if n <= c.size {
+			ch, err := chunk.New(joined, start, end, n)
+			if err != nil {
+				return err
+			}
+			out = append(out, ch)
+		} else {
+			more, err := c.hardSplit(joined, start)
+			if err != nil {
+				return err
+			}
+			out = append(out, more...)
+		}
+		buf = buf[:0]
+		tokens = 0
+		return nil
+	}
+
+	for _, p := range pieces {
+		n := c.tok.Count(p.Text)
+		if len(buf) > 0 && tokens+n > c.size {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+		}
+		buf = append(buf, p)
+		tokens += n
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+type piece struct {
+	Text  string
+	Start int
+	End   int
+}
+
+func (c Chunker) declPieces(text string) []piece {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "src.go", text, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		return nil
+	}
+
+	cuts := []int{0, len(text)}
+	for _, d := range f.Decls {
+		start, _ := declSpan(d)
+		off := fset.Position(start).Offset
+		if off > 0 && off < len(text) {
+			cuts = append(cuts, off)
+		}
+	}
+	sort.Ints(cuts)
+	uniq := cuts[:0]
+	prev := -1
+	for _, x := range cuts {
+		if x != prev {
+			uniq = append(uniq, x)
+			prev = x
+		}
+	}
+
+	out := make([]piece, 0, len(uniq)-1)
+	for i := 0; i < len(uniq)-1; i++ {
+		a, b := uniq[i], uniq[i+1]
+		if a == b {
+			continue
+		}
+		seg := text[a:b]
+		out = append(out, piece{
+			Text:  seg,
+			Start: utf8.RuneCountInString(text[:a]),
+			End:   utf8.RuneCountInString(text[:b]),
+		})
+	}
+	return out
+}
+
+func declSpan(d ast.Decl) (token.Pos, token.Pos) {
+	start, end := d.Pos(), d.End()
+	switch x := d.(type) {
+	case *ast.FuncDecl:
+		if x.Doc != nil {
+			start = x.Doc.Pos()
+		}
+	case *ast.GenDecl:
+		if x.Doc != nil {
+			start = x.Doc.Pos()
+		}
+	}
+	return start, end
+}
+
+func (c Chunker) hardSplit(text string, offset int) ([]chunk.Chunk, error) {
+	chunks, err := c.hard.Chunk(text)
+	if err != nil {
+		return nil, err
+	}
+	if offset == 0 {
+		return chunks, nil
+	}
+	out := make([]chunk.Chunk, len(chunks))
+	for i, ch := range chunks {
+		ch.Start += offset
+		ch.End += offset
+		out[i] = ch
+	}
+	return out, nil
+}

--- a/pkg/codechunker/chunker_test.go
+++ b/pkg/codechunker/chunker_test.go
@@ -1,0 +1,153 @@
+package codechunker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bluesky585/nibble/internal/assertchunk"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(nil, 8)
+	if err == nil || !strings.Contains(err.Error(), "tokenizer is required") {
+		t.Fatalf("err=%v", err)
+	}
+	_, err = New(tokenizer.Character{}, 0)
+	if err == nil || !strings.Contains(err.Error(), "size must be > 0") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestChunkPacksSmallFile(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 512)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "package p\n\nfunc A() {}\n\nfunc B() {}\n"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if len(got) != 1 {
+		t.Fatalf("len=%d want 1", len(got))
+	}
+}
+
+func TestChunkSplitsFunctions(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 24)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "package p\n\nfunc A() {}\n\nfunc B() {}\n"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if len(got) < 2 {
+		t.Fatalf("expected funcs in separate chunks, got %+v", got)
+	}
+	joined := ""
+	for _, ch := range got {
+		joined += ch.Text
+	}
+	if !strings.Contains(joined, "func A()") || !strings.Contains(joined, "func B()") {
+		t.Fatalf("missing funcs: %+v", got)
+	}
+}
+
+func TestChunkKeepsDocCommentWithFunc(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 40)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "package p\n\n// Hello does a thing.\nfunc Hello() {}\n"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+
+	found := false
+	for _, ch := range got {
+		if strings.Contains(ch.Text, "Hello does a thing") && strings.Contains(ch.Text, "func Hello") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("doc comment should stay with the func: %+v", got)
+	}
+}
+
+func TestChunkParseFallback(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "not go source at all"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if got[0].Text != "not" {
+		t.Fatalf("expected token fallback, got %+v", got)
+	}
+}
+
+func TestChunkEmpty(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.Chunk("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, "", got)
+}
+
+func TestChunkUnicodeComment(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, 512)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "package p\n\n// 你好\nfunc A() {}\n"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if got[0].End != runeCount(original) {
+		t.Fatalf("end=%d want %d", got[0].End, runeCount(original))
+	}
+}
+
+func runeCount(s string) int {
+	n := 0
+	for range s {
+		n++
+	}
+	return n
+}


### PR DESCRIPTION
## Summary
- Add `codechunker`: parse Go with `go/parser` / `go/ast` (stdlib only).
- Cut on top-level decls; doc comments stay with the following decl.
- Pack decls up to `-size`. Oversized decls and non-Go text use token windows.
- CLI/API: `-chunker code`.

## Test plan
- [x] `go test ./...`
- [ ] Two small funcs with a tight size land in different chunks and still reconstruct.
- [ ] `// Hello does a thing.` stays in the same chunk as `func Hello`.
- [ ] `not go source at all` falls back to token windows.