### PR TITLE
Add semantic sentence packing with a local embedder

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 
 | Flag | Default | Meaning |
 | --- | --- | --- |
-| `-chunker` | `recursive` | `recursive`, `sentence`, `token`, `fast`, `table`, or `code` |
+| `-chunker` | `recursive` | `recursive`, `sentence`, `token`, `fast`, `table`, `code`, or `semantic` |
 | `-tokenizer` | `character` | `character` or `word` (ignored by `fast`) |
 | `-size` | `512` | max tokens per chunk; **max bytes** for `fast` |
 | `-overlap` | `0` | token overlap; token chunker only |
@@ -33,6 +33,8 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 `table` splits GitHub-flavored Markdown tables by row. Later row-groups copy the header into `context` so retrieval keeps column names; `text` stays a slice of the original, so reconstruct still works.
 
 `code` splits Go source on top-level declarations (package, types, funcs), keeping doc comments with the decl. If the file does not parse, it falls back to token windows.
+
+`semantic` embeds sentences with a local hashing vector (no API) and starts a new chunk when cosine similarity drops below 0.5 or the token budget is full. `Embedder` is an interface; swap in a model later.
 
 ## HTTP API
 

--- a/internal/buildchunk/build.go
+++ b/internal/buildchunk/build.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/bluesky585/nibble/pkg/chunk"
 	"github.com/bluesky585/nibble/pkg/codechunker"
+	"github.com/bluesky585/nibble/pkg/embed"
 	"github.com/bluesky585/nibble/pkg/fastchunker"
 	"github.com/bluesky585/nibble/pkg/recursive"
+	"github.com/bluesky585/nibble/pkg/semantic"
 	"github.com/bluesky585/nibble/pkg/sentencechunker"
 	"github.com/bluesky585/nibble/pkg/tablechunker"
 	"github.com/bluesky585/nibble/pkg/tokenchunker"
@@ -58,6 +60,11 @@ func New(chunkerName, tokName string, size, overlap int) (Chunker, error) {
 			return nil, fmt.Errorf("overlap is only supported by the token chunker")
 		}
 		return codechunker.New(tok, size)
+	case "semantic":
+		if overlap != 0 {
+			return nil, fmt.Errorf("overlap is only supported by the token chunker")
+		}
+		return semantic.New(tok, embed.Hashing{}, size, 0)
 	default:
 		return nil, fmt.Errorf("unknown chunker %q", chunkerName)
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,7 +24,7 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		fs.PrintDefaults()
 	}
 
-	chunkerName := fs.String("chunker", "recursive", "chunker: recursive, sentence, token, fast, table, or code")
+	chunkerName := fs.String("chunker", "recursive", "chunker: recursive, sentence, token, fast, table, code, or semantic")
 	tokName := fs.String("tokenizer", "character", "tokenizer: character or word (ignored by fast)")
 	size := fs.Int("size", 512, "max tokens per chunk (max bytes for fast)")
 	overlap := fs.Int("overlap", 0, "token overlap (token chunker only)")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -55,6 +55,23 @@ func TestRunFile(t *testing.T) {
 	}
 }
 
+func TestRunSemantic(t *testing.T) {
+	t.Parallel()
+
+	original := "Cats sleep. Quantum chromodynamics is hard."
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "semantic", "-size", "512"}, strings.NewReader(original), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+
+	var chunks []chunk.Chunk
+	if err := json.Unmarshal(stdout.Bytes(), &chunks); err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, chunks)
+}
+
 func TestRunCode(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/embed/embed.go
+++ b/pkg/embed/embed.go
@@ -1,0 +1,8 @@
+// Package embed turns text into vectors for semantic splitting.
+package embed
+
+// Embedder maps texts to dense vectors. Callers pass a batch; the
+// implementation must not create a new client per item.
+type Embedder interface {
+	Embed(texts []string) ([][]float64, error)
+}

--- a/pkg/embed/hashing.go
+++ b/pkg/embed/hashing.go
@@ -1,0 +1,29 @@
+package embed
+
+import (
+	"hash/fnv"
+	"strings"
+)
+
+const hashingDim = 64
+
+// Hashing embeds text with a bag-of-words hashing trick.
+// Same words land in the same slots, so overlapping wording is similar.
+// It needs no network and is deterministic.
+type Hashing struct{}
+
+// Embed returns one hashingDim vector per input. An empty string is zeros.
+func (Hashing) Embed(texts []string) ([][]float64, error) {
+	out := make([][]float64, len(texts))
+	h := fnv.New32a()
+	for i, text := range texts {
+		v := make([]float64, hashingDim)
+		for _, word := range strings.Fields(strings.ToLower(text)) {
+			h.Reset()
+			_, _ = h.Write([]byte(word))
+			v[int(h.Sum32())%hashingDim] += 1
+		}
+		out[i] = v
+	}
+	return out, nil
+}

--- a/pkg/embed/hashing_test.go
+++ b/pkg/embed/hashing_test.go
@@ -1,0 +1,65 @@
+package embed
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+func cosine(a, b []float64) float64 {
+	var dot, na, nb float64
+	for i := range a {
+		dot += a[i] * b[i]
+		na += a[i] * a[i]
+		nb += b[i] * b[i]
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+func TestHashingSimilarWording(t *testing.T) {
+	t.Parallel()
+
+	vecs, err := Hashing{}.Embed([]string{
+		"cats sleep",
+		"cats eat",
+		"quantum chromodynamics",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cosine(vecs[0], vecs[1]) < cosine(vecs[0], vecs[2]) {
+		t.Fatalf("overlapping words should be closer: %v %v %v",
+			cosine(vecs[0], vecs[1]), cosine(vecs[0], vecs[2]), vecs)
+	}
+}
+
+func TestHashingDeterministic(t *testing.T) {
+	t.Parallel()
+
+	a, err := Hashing{}.Embed([]string{"hello world"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Hashing{}.Embed([]string{"hello world"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(a[0], b[0]) {
+		t.Fatalf("same input must be identical")
+	}
+}
+
+func TestHashingBatchLen(t *testing.T) {
+	t.Parallel()
+
+	vecs, err := Hashing{}.Embed([]string{"a", "", "b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vecs) != 3 || len(vecs[1]) != hashingDim {
+		t.Fatalf("got %d vecs", len(vecs))
+	}
+}

--- a/pkg/semantic/chunker.go
+++ b/pkg/semantic/chunker.go
@@ -1,0 +1,129 @@
+// Package semantic packs sentences that are similar in embedding space.
+package semantic
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/embed"
+	"github.com/bluesky585/nibble/pkg/sentencechunker"
+	"github.com/bluesky585/nibble/pkg/split"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+const defaultMinSim = 0.5
+
+// Chunker splits on sentences, then starts a new chunk when the next
+// sentence is dissimilar or the token budget is full.
+type Chunker struct {
+	tok    tokenizer.Tokenizer
+	emb    embed.Embedder
+	size   int
+	minSim float64
+}
+
+// New builds a Chunker. minSim 0 uses 0.5. Similarity is cosine in [0, 1]
+// for the hashing embedder (non-negative counts).
+func New(tok tokenizer.Tokenizer, emb embed.Embedder, size int, minSim float64) (Chunker, error) {
+	if tok == nil {
+		return Chunker{}, fmt.Errorf("tokenizer is required")
+	}
+	if emb == nil {
+		return Chunker{}, fmt.Errorf("embedder is required")
+	}
+	if size <= 0 {
+		return Chunker{}, fmt.Errorf("size must be > 0, got %d", size)
+	}
+	if minSim == 0 {
+		minSim = defaultMinSim
+	}
+	if minSim < 0 || minSim > 1 {
+		return Chunker{}, fmt.Errorf("minSim must be in [0, 1], got %v", minSim)
+	}
+	return Chunker{tok: tok, emb: emb, size: size, minSim: minSim}, nil
+}
+
+// Chunk splits text. Sentence embeddings are requested in one batch.
+func (c Chunker) Chunk(text string) ([]chunk.Chunk, error) {
+	pieces, err := split.Text(text, split.Options{
+		Delimiters: sentencechunker.DefaultDelimiters,
+		Attach:     split.AttachPrev,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(pieces) == 0 {
+		return nil, nil
+	}
+
+	texts := make([]string, len(pieces))
+	for i, p := range pieces {
+		texts[i] = p.Text
+	}
+	vecs, err := c.emb.Embed(texts)
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) != len(pieces) {
+		return nil, fmt.Errorf("embedder returned %d vectors for %d sentences", len(vecs), len(pieces))
+	}
+
+	var out []chunk.Chunk
+	var buf []split.Piece
+	tokens := 0
+
+	flush := func() error {
+		if len(buf) == 0 {
+			return nil
+		}
+		var b strings.Builder
+		n := 0
+		for _, p := range buf {
+			b.WriteString(p.Text)
+			n += c.tok.Count(p.Text)
+		}
+		ch, err := chunk.New(b.String(), buf[0].Start, buf[len(buf)-1].End, n)
+		if err != nil {
+			return err
+		}
+		out = append(out, ch)
+		buf = buf[:0]
+		tokens = 0
+		return nil
+	}
+
+	for i, p := range pieces {
+		n := c.tok.Count(p.Text)
+		if len(buf) > 0 {
+			if tokens+n > c.size || cosine(vecs[i-1], vecs[i]) < c.minSim {
+				if err := flush(); err != nil {
+					return nil, err
+				}
+			}
+		}
+		buf = append(buf, p)
+		tokens += n
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func cosine(a, b []float64) float64 {
+	if len(a) == 0 || len(a) != len(b) {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		dot += a[i] * b[i]
+		na += a[i] * a[i]
+		nb += b[i] * b[i]
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}

--- a/pkg/semantic/chunker_test.go
+++ b/pkg/semantic/chunker_test.go
@@ -1,0 +1,103 @@
+package semantic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bluesky585/nibble/internal/assertchunk"
+	"github.com/bluesky585/nibble/pkg/embed"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(nil, embed.Hashing{}, 8, 0)
+	if err == nil || !strings.Contains(err.Error(), "tokenizer is required") {
+		t.Fatalf("err=%v", err)
+	}
+	_, err = New(tokenizer.Character{}, nil, 8, 0)
+	if err == nil || !strings.Contains(err.Error(), "embedder is required") {
+		t.Fatalf("err=%v", err)
+	}
+	_, err = New(tokenizer.Character{}, embed.Hashing{}, 0, 0)
+	if err == nil || !strings.Contains(err.Error(), "size must be > 0") {
+		t.Fatalf("err=%v", err)
+	}
+	_, err = New(tokenizer.Character{}, embed.Hashing{}, 8, 2)
+	if err == nil || !strings.Contains(err.Error(), "minSim") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestChunkSplitsDissimilarSentences(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, embed.Hashing{}, 512, 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "Cats sleep. Cats eat. Quantum chromodynamics is hard."
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if len(got) < 2 {
+		t.Fatalf("expected a topic break, got %+v", got)
+	}
+	last := got[len(got)-1].Text
+	if !strings.Contains(last, "Quantum") {
+		t.Fatalf("quantum sentence should start a new chunk, got %+v", got)
+	}
+}
+
+func TestChunkRespectsSize(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, embed.Hashing{}, 12, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "Cats sleep. Cats eat."
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if len(got) < 2 {
+		t.Fatalf("size 12 should split these sentences, got %+v", got)
+	}
+}
+
+func TestChunkEmpty(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, embed.Hashing{}, 8, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.Chunk("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, "", got)
+}
+
+func TestChunkUnicode(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(tokenizer.Character{}, embed.Hashing{}, 64, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := "你好。世界！"
+	got, err := c.Chunk(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+}


### PR DESCRIPTION
## Summary
- Add `embed.Embedder` with a batch `Embed([]string)` API (one hasher reused, no per-item client).
- Add `embed.Hashing`: deterministic bag-of-words hashing, no network.
- Add `semantic` chunker: split sentences, embed once, pack while cosine ≥ 0.5 and tokens fit.
- CLI/API: `-chunker semantic`.

## Test plan
- [x] `go test ./...`
- [ ] `Cats sleep. Cats eat. Quantum chromodynamics is hard.` should break before Quantum.
- [ ] Reconstruct still equals the original.