### PR TITLE
Add a cosine vector store with memory and JSONL backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 | `-tokenizer` | `character` | `character` or `word` (ignored by `fast`) |
 | `-size` | `512` | max tokens per chunk; **max bytes** for `fast` |
 | `-overlap` | `0` | token overlap; token chunker only |
+| `-index` | | optional JSONL file of chunk embeddings (hashing vectors) |
 
 `fast` looks for a delimiter near the byte budget and never splits a UTF-8 rune. JSON `start`/`end` are still rune offsets.
 
@@ -35,6 +36,8 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 `code` splits Go source on top-level declarations (package, types, funcs), keeping doc comments with the decl. If the file does not parse, it falls back to token windows.
 
 `semantic` embeds sentences with a local hashing vector (no API) and starts a new chunk when cosine similarity drops below 0.5 or the token budget is full. `Embedder` is an interface; swap in a model later.
+
+`-index` writes those chunks plus hashing vectors to a JSONL file (`pkg/store`). Search is brute-force cosine; swap the `Store` for a real database later.
 
 ## HTTP API
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/bluesky585/nibble/internal/buildchunk"
 	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/embed"
+	"github.com/bluesky585/nibble/pkg/store"
 )
 
 // Run parses args, chunks input, and writes JSON chunks to stdout.
@@ -28,6 +30,7 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	tokName := fs.String("tokenizer", "character", "tokenizer: character or word (ignored by fast)")
 	size := fs.Int("size", 512, "max tokens per chunk (max bytes for fast)")
 	overlap := fs.Int("overlap", 0, "token overlap (token chunker only)")
+	indexPath := fs.String("index", "", "optional JSONL path to store chunk embeddings")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -52,6 +55,18 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	if chunks == nil {
 		chunks = []chunk.Chunk{}
+	}
+
+	if *indexPath != "" {
+		st, err := store.OpenJSONL(*indexPath)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if err := store.Index(st, embed.Hashing{}, chunks); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
 	}
 
 	enc := json.NewEncoder(stdout)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/bluesky585/nibble/internal/assertchunk"
 	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/embed"
+	"github.com/bluesky585/nibble/pkg/store"
 )
 
 func TestRunStdin(t *testing.T) {
@@ -52,6 +54,34 @@ func TestRunFile(t *testing.T) {
 	assertchunk.Split(t, original, chunks)
 	if chunks[0].End != 3 {
 		t.Fatalf("want rune offsets, first end=%d", chunks[0].End)
+	}
+}
+
+func TestRunIndex(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "idx.jsonl")
+	original := "cats sleep. quantum chromodynamics."
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "sentence", "-size", "64", "-index", path}, strings.NewReader(original), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+
+	st, err := store.OpenJSONL(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := embed.Hashing{}.Embed([]string{"cats"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits, err := st.Search(q[0], 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || !strings.Contains(hits[0].Record.Chunk.Text, "cats") {
+		t.Fatalf("got %+v", hits)
 	}
 }
 

--- a/pkg/embed/cosine.go
+++ b/pkg/embed/cosine.go
@@ -1,0 +1,21 @@
+package embed
+
+import "math"
+
+// Cosine returns the cosine similarity of a and b.
+// A zero or mismatched vector yields 0.
+func Cosine(a, b []float64) float64 {
+	if len(a) == 0 || len(a) != len(b) {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		dot += a[i] * b[i]
+		na += a[i] * a[i]
+		nb += b[i] * b[i]
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}

--- a/pkg/embed/hashing_test.go
+++ b/pkg/embed/hashing_test.go
@@ -1,23 +1,9 @@
 package embed
 
 import (
-	"math"
 	"reflect"
 	"testing"
 )
-
-func cosine(a, b []float64) float64 {
-	var dot, na, nb float64
-	for i := range a {
-		dot += a[i] * b[i]
-		na += a[i] * a[i]
-		nb += b[i] * b[i]
-	}
-	if na == 0 || nb == 0 {
-		return 0
-	}
-	return dot / (math.Sqrt(na) * math.Sqrt(nb))
-}
 
 func TestHashingSimilarWording(t *testing.T) {
 	t.Parallel()
@@ -30,9 +16,9 @@ func TestHashingSimilarWording(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cosine(vecs[0], vecs[1]) < cosine(vecs[0], vecs[2]) {
+	if Cosine(vecs[0], vecs[1]) < Cosine(vecs[0], vecs[2]) {
 		t.Fatalf("overlapping words should be closer: %v %v %v",
-			cosine(vecs[0], vecs[1]), cosine(vecs[0], vecs[2]), vecs)
+			Cosine(vecs[0], vecs[1]), Cosine(vecs[0], vecs[2]), vecs)
 	}
 }
 

--- a/pkg/semantic/chunker.go
+++ b/pkg/semantic/chunker.go
@@ -3,7 +3,6 @@ package semantic
 
 import (
 	"fmt"
-	"math"
 	"strings"
 
 	"github.com/bluesky585/nibble/pkg/chunk"
@@ -97,7 +96,7 @@ func (c Chunker) Chunk(text string) ([]chunk.Chunk, error) {
 	for i, p := range pieces {
 		n := c.tok.Count(p.Text)
 		if len(buf) > 0 {
-			if tokens+n > c.size || cosine(vecs[i-1], vecs[i]) < c.minSim {
+			if tokens+n > c.size || embed.Cosine(vecs[i-1], vecs[i]) < c.minSim {
 				if err := flush(); err != nil {
 					return nil, err
 				}
@@ -110,20 +109,4 @@ func (c Chunker) Chunk(text string) ([]chunk.Chunk, error) {
 		return nil, err
 	}
 	return out, nil
-}
-
-func cosine(a, b []float64) float64 {
-	if len(a) == 0 || len(a) != len(b) {
-		return 0
-	}
-	var dot, na, nb float64
-	for i := range a {
-		dot += a[i] * b[i]
-		na += a[i] * a[i]
-		nb += b[i] * b[i]
-	}
-	if na == 0 || nb == 0 {
-		return 0
-	}
-	return dot / (math.Sqrt(na) * math.Sqrt(nb))
 }

--- a/pkg/store/jsonl.go
+++ b/pkg/store/jsonl.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// JSONL stores records in a JSON Lines file. Each Upsert rewrites the file.
+type JSONL struct {
+	path    string
+	records []Record
+}
+
+// OpenJSONL loads existing records from path. A missing file is empty.
+func OpenJSONL(path string) (*JSONL, error) {
+	if path == "" {
+		return nil, fmt.Errorf("path is required")
+	}
+	s := &JSONL{path: path}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec Record
+		if err := json.Unmarshal(line, &rec); err != nil {
+			return nil, err
+		}
+		s.records = append(s.records, rec)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Upsert appends records and writes the whole file once.
+func (s *JSONL) Upsert(records []Record) error {
+	s.records = append(s.records, records...)
+
+	f, err := os.Create(s.path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	for _, rec := range s.records {
+		if err := enc.Encode(rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Search returns the k nearest records by cosine similarity.
+func (s *JSONL) Search(query []float64, k int) ([]Hit, error) {
+	return searchRecords(s.records, query, k)
+}

--- a/pkg/store/memory.go
+++ b/pkg/store/memory.go
@@ -1,0 +1,17 @@
+package store
+
+// Memory keeps records in process. It is not safe for concurrent use.
+type Memory struct {
+	records []Record
+}
+
+// Upsert appends records.
+func (m *Memory) Upsert(records []Record) error {
+	m.records = append(m.records, records...)
+	return nil
+}
+
+// Search returns the k nearest records by cosine similarity.
+func (m *Memory) Search(query []float64, k int) ([]Hit, error) {
+	return searchRecords(m.records, query, k)
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,0 +1,84 @@
+// Package store persists chunk embeddings and searches by cosine similarity.
+package store
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/embed"
+)
+
+// Record is a chunk plus its embedding.
+type Record struct {
+	Chunk  chunk.Chunk `json:"chunk"`
+	Vector []float64   `json:"vector"`
+}
+
+// Hit is a search result.
+type Hit struct {
+	Record Record  `json:"record"`
+	Score  float64 `json:"score"`
+}
+
+// Store upserts records and runs brute-force cosine search.
+type Store interface {
+	Upsert(records []Record) error
+	Search(query []float64, k int) ([]Hit, error)
+}
+
+// Index embeds chunks in one batch and writes them to st.
+// Context is prefixed onto the embedded text when present.
+func Index(st Store, emb embed.Embedder, chunks []chunk.Chunk) error {
+	if st == nil {
+		return fmt.Errorf("store is required")
+	}
+	if emb == nil {
+		return fmt.Errorf("embedder is required")
+	}
+	if len(chunks) == 0 {
+		return nil
+	}
+
+	texts := make([]string, len(chunks))
+	for i, ch := range chunks {
+		if ch.Context != "" {
+			texts[i] = ch.Context + ch.Text
+		} else {
+			texts[i] = ch.Text
+		}
+	}
+	vecs, err := emb.Embed(texts)
+	if err != nil {
+		return err
+	}
+	if len(vecs) != len(chunks) {
+		return fmt.Errorf("embedder returned %d vectors for %d chunks", len(vecs), len(chunks))
+	}
+
+	records := make([]Record, len(chunks))
+	for i := range chunks {
+		records[i] = Record{Chunk: chunks[i], Vector: vecs[i]}
+	}
+	return st.Upsert(records)
+}
+
+func searchRecords(records []Record, query []float64, k int) ([]Hit, error) {
+	if k <= 0 {
+		return nil, fmt.Errorf("k must be > 0, got %d", k)
+	}
+	hits := make([]Hit, 0, len(records))
+	for _, rec := range records {
+		hits = append(hits, Hit{Record: rec, Score: embed.Cosine(query, rec.Vector)})
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].Score == hits[j].Score {
+			return hits[i].Record.Chunk.Start < hits[j].Record.Chunk.Start
+		}
+		return hits[i].Score > hits[j].Score
+	})
+	if k > len(hits) {
+		k = len(hits)
+	}
+	return hits[:k], nil
+}

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1,0 +1,103 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/embed"
+)
+
+func mustChunk(t *testing.T, text string, start int) chunk.Chunk {
+	t.Helper()
+	n := utf8.RuneCountInString(text)
+	c, err := chunk.New(text, start, start+n, n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestMemorySearch(t *testing.T) {
+	t.Parallel()
+
+	chunks := []chunk.Chunk{
+		mustChunk(t, "cats sleep on mats", 0),
+		mustChunk(t, "quantum chromodynamics", 20),
+	}
+	mem := &Memory{}
+	if err := Index(mem, embed.Hashing{}, chunks); err != nil {
+		t.Fatal(err)
+	}
+
+	q, err := embed.Hashing{}.Embed([]string{"cats eat"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits, err := mem.Search(q[0], 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("len=%d", len(hits))
+	}
+	if hits[0].Record.Chunk.Text != "cats sleep on mats" {
+		t.Fatalf("top hit=%q", hits[0].Record.Chunk.Text)
+	}
+	if hits[0].Score < hits[1].Score {
+		t.Fatalf("hits not ordered: %+v", hits)
+	}
+}
+
+func TestJSONLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "index.jsonl")
+	st, err := OpenJSONL(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chunks := []chunk.Chunk{
+		mustChunk(t, "cats sleep", 0),
+		mustChunk(t, "quantum field", 11),
+	}
+	if err := Index(st, embed.Hashing{}, chunks); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := OpenJSONL(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := embed.Hashing{}.Embed([]string{"cats"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits, err := loaded.Search(q[0], 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || hits[0].Record.Chunk.Text != "cats sleep" {
+		t.Fatalf("got %+v", hits)
+	}
+}
+
+func TestIndexEmpty(t *testing.T) {
+	t.Parallel()
+
+	mem := &Memory{}
+	if err := Index(mem, embed.Hashing{}, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSearchBadK(t *testing.T) {
+	t.Parallel()
+
+	_, err := (&Memory{}).Search(nil, 0)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `store.Store` with `Upsert` and `Search`.
- `Memory` for tests; `JSONL` rewrites one file per batch upsert (no per-row client).
- `store.Index` embeds all chunk texts in one `Embed` call (prefixes `Context` when set).
- CLI: `-index path.jsonl` after chunking.
- `embed.Cosine` shared with the semantic chunker.

## Test plan
- [x] `go test ./...`
- [ ] Index `cats sleep` and `quantum field`; query `cats` returns the cat chunk.
- [ ] Re-open the JSONL file and search still works.