### PR TITLE
Add an OpenAI-compatible embedding client

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 | `-tokenizer` | `character` | `character` or `word` (ignored by `fast`) |
 | `-size` | `512` | max tokens per chunk; **max bytes** for `fast` |
 | `-overlap` | `0` | token overlap; token chunker only |
-| `-index` | | optional JSONL file of chunk embeddings (hashing vectors) |
+| `-index` | | optional JSONL file of chunk embeddings |
+| `-embedder` | `hashing` | `hashing` or `openai` (used by `semantic` and `-index`) |
 
 `fast` looks for a delimiter near the byte budget and never splits a UTF-8 rune. JSON `start`/`end` are still rune offsets.
 
@@ -35,9 +36,11 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 
 `code` splits Go source on top-level declarations (package, types, funcs), keeping doc comments with the decl. If the file does not parse, it falls back to token windows.
 
-`semantic` embeds sentences with a local hashing vector (no API) and starts a new chunk when cosine similarity drops below 0.5 or the token budget is full. `Embedder` is an interface; swap in a model later.
+`semantic` embeds sentences and starts a new chunk when cosine similarity drops below 0.5 or the token budget is full.
 
-`-index` writes those chunks plus hashing vectors to a JSONL file (`pkg/store`). Search is brute-force cosine; swap the `Store` for a real database later.
+`-embedder hashing` is local and needs no network. `-embedder openai` calls an OpenAI-compatible `/v1/embeddings` API (`OPENAI_API_KEY`, optional `OPENAI_BASE_URL`, `OPENAI_EMBED_MODEL`). One HTTP request per batch.
+
+`-index` writes chunks plus vectors from the selected embedder to JSONL.
 
 ## HTTP API
 
@@ -58,7 +61,8 @@ go run ./cmd/nibble-api -addr 127.0.0.1:8080
   "chunker": "recursive",
   "tokenizer": "character",
   "size": 512,
-  "overlap": 0
+  "overlap": 0,
+  "embedder": "hashing"
 }
 ```
 

--- a/internal/buildchunk/build.go
+++ b/internal/buildchunk/build.go
@@ -24,7 +24,8 @@ type Chunker interface {
 // New builds a chunker. overlap is valid only for the token chunker.
 // The tokenizer is ignored when chunkerName is "fast"; size is then a
 // byte budget, while chunk offsets remain runes.
-func New(chunkerName, tokName string, size, overlap int) (Chunker, error) {
+// emb is used by the semantic chunker; nil means embed.Hashing.
+func New(chunkerName, tokName string, size, overlap int, emb embed.Embedder) (Chunker, error) {
 	if chunkerName == "fast" {
 		if overlap != 0 {
 			return nil, fmt.Errorf("overlap is only supported by the token chunker")
@@ -64,7 +65,10 @@ func New(chunkerName, tokName string, size, overlap int) (Chunker, error) {
 		if overlap != 0 {
 			return nil, fmt.Errorf("overlap is only supported by the token chunker")
 		}
-		return semantic.New(tok, embed.Hashing{}, size, 0)
+		if emb == nil {
+			emb = embed.Hashing{}
+		}
+		return semantic.New(tok, emb, size, 0)
 	default:
 		return nil, fmt.Errorf("unknown chunker %q", chunkerName)
 	}

--- a/internal/buildchunk/build_test.go
+++ b/internal/buildchunk/build_test.go
@@ -10,7 +10,7 @@ import (
 func TestNewRecursive(t *testing.T) {
 	t.Parallel()
 
-	c, err := New("recursive", "character", 64, 0)
+	c, err := New("recursive", "character", 64, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func TestNewRecursive(t *testing.T) {
 func TestNewOverlapRejected(t *testing.T) {
 	t.Parallel()
 
-	_, err := New("sentence", "character", 64, 1)
+	_, err := New("sentence", "character", 64, 1, nil)
 	if err == nil || !strings.Contains(err.Error(), "overlap is only supported by the token chunker") {
 		t.Fatalf("err=%v", err)
 	}
@@ -34,7 +34,7 @@ func TestNewOverlapRejected(t *testing.T) {
 func TestNewFast(t *testing.T) {
 	t.Parallel()
 
-	c, err := New("fast", "character", 8, 0)
+	c, err := New("fast", "character", 8, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,11 +49,11 @@ func TestNewFast(t *testing.T) {
 func TestNewUnknown(t *testing.T) {
 	t.Parallel()
 
-	_, err := New("magic", "character", 8, 0)
+	_, err := New("magic", "character", 8, 0, nil)
 	if err == nil || !strings.Contains(err.Error(), "unknown chunker") {
 		t.Fatalf("err=%v", err)
 	}
-	_, err = New("token", "emoji", 8, 0)
+	_, err = New("token", "emoji", 8, 0, nil)
 	if err == nil || !strings.Contains(err.Error(), "unknown tokenizer") {
 		t.Fatalf("err=%v", err)
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -31,6 +31,7 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	size := fs.Int("size", 512, "max tokens per chunk (max bytes for fast)")
 	overlap := fs.Int("overlap", 0, "token overlap (token chunker only)")
 	indexPath := fs.String("index", "", "optional JSONL path to store chunk embeddings")
+	embedderName := fs.String("embedder", "hashing", "embedder: hashing or openai (semantic and -index)")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -42,7 +43,13 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	c, err := buildchunk.New(*chunkerName, *tokName, *size, *overlap)
+	emb, err := embed.Lookup(*embedderName)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+
+	c, err := buildchunk.New(*chunkerName, *tokName, *size, *overlap, emb)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 2
@@ -63,7 +70,7 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		if err := store.Index(st, embed.Hashing{}, chunks); err != nil {
+		if err := store.Index(st, emb, chunks); err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -187,6 +187,16 @@ func TestRunOverlapRejected(t *testing.T) {
 	}
 }
 
+func TestRunUnknownEmbedder(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-embedder", "magic"}, strings.NewReader("hi"), &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit %d want 2 stderr=%s", code, stderr.String())
+	}
+}
+
 func TestRunUnknownChunker(t *testing.T) {
 	t.Parallel()
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bluesky585/nibble/internal/buildchunk"
 	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/embed"
 )
 
 const maxBody = 10 << 20
@@ -29,6 +30,7 @@ type chunkRequest struct {
 	Tokenizer string `json:"tokenizer"`
 	Size      int    `json:"size"`
 	Overlap   int    `json:"overlap"`
+	Embedder  string `json:"embedder"`
 }
 
 type chunkResponse struct {
@@ -60,7 +62,13 @@ func chunkText(w http.ResponseWriter, r *http.Request) {
 		req.Size = 512
 	}
 
-	c, err := buildchunk.New(req.Chunker, req.Tokenizer, req.Size, req.Overlap)
+	emb, err := embed.Lookup(req.Embedder)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+		return
+	}
+
+	c, err := buildchunk.New(req.Chunker, req.Tokenizer, req.Size, req.Overlap, emb)
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
 		return

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -85,6 +85,17 @@ func TestChunkEmpty(t *testing.T) {
 	assertchunk.Split(t, "", resp.Chunks)
 }
 
+func TestChunkBadEmbedder(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chunk", strings.NewReader(`{"text":"hi","embedder":"magic"}`))
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestChunkBadOptions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/embed/lookup.go
+++ b/pkg/embed/lookup.go
@@ -1,0 +1,18 @@
+package embed
+
+import "fmt"
+
+// Lookup returns a named embedder.
+//
+//	hashing (default): local bag-of-words, no network
+//	openai: OpenAI-compatible HTTP, requires OPENAI_API_KEY
+func Lookup(name string) (Embedder, error) {
+	switch name {
+	case "", "hashing":
+		return Hashing{}, nil
+	case "openai":
+		return NewOpenAIFromEnv()
+	default:
+		return nil, fmt.Errorf("unknown embedder %q", name)
+	}
+}

--- a/pkg/embed/lookup_test.go
+++ b/pkg/embed/lookup_test.go
@@ -1,0 +1,14 @@
+package embed
+
+import "testing"
+
+func TestLookupOpenAINeedsKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_BASE_URL", "")
+	t.Setenv("OPENAI_EMBED_MODEL", "")
+
+	_, err := Lookup("openai")
+	if err == nil {
+		t.Fatal("expected missing API key")
+	}
+}

--- a/pkg/embed/openai.go
+++ b/pkg/embed/openai.go
@@ -1,0 +1,144 @@
+package embed
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	defaultOpenAIBase  = "https://api.openai.com/v1"
+	defaultOpenAIModel = "text-embedding-3-small"
+)
+
+// OpenAI calls an OpenAI-compatible /v1/embeddings endpoint.
+// Client is reused for every Embed call; do not construct OpenAI in a loop.
+type OpenAI struct {
+	client  *http.Client
+	baseURL string
+	apiKey  string
+	model   string
+}
+
+// NewOpenAI builds a client. nil httpClient uses http.DefaultClient.
+// Empty baseURL or model use the OpenAI defaults.
+func NewOpenAI(httpClient *http.Client, baseURL, apiKey, model string) (*OpenAI, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("API key is required")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	if baseURL == "" {
+		baseURL = defaultOpenAIBase
+	}
+	if model == "" {
+		model = defaultOpenAIModel
+	}
+	return &OpenAI{
+		client:  httpClient,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		apiKey:  apiKey,
+		model:   model,
+	}, nil
+}
+
+// NewOpenAIFromEnv reads OPENAI_API_KEY, optional OPENAI_BASE_URL and
+// OPENAI_EMBED_MODEL.
+func NewOpenAIFromEnv() (*OpenAI, error) {
+	return NewOpenAI(nil, os.Getenv("OPENAI_BASE_URL"), os.Getenv("OPENAI_API_KEY"), os.Getenv("OPENAI_EMBED_MODEL"))
+}
+
+type openaiRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type openaiResponse struct {
+	Data []struct {
+		Index     int       `json:"index"`
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// Embed sends the whole batch in one HTTP request.
+func (o *OpenAI) Embed(texts []string) ([][]float64, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(openaiRequest{Model: o.model, Input: texts}); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, o.embeddingsURL(), &body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+o.apiKey)
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed openaiResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("decode embeddings response: %w", err)
+	}
+	if parsed.Error != nil && parsed.Error.Message != "" {
+		return nil, fmt.Errorf("embeddings API: %s", parsed.Error.Message)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("embeddings API HTTP %d: %s", resp.StatusCode, truncate(raw, 256))
+	}
+	if len(parsed.Data) != len(texts) {
+		return nil, fmt.Errorf("embeddings API returned %d vectors for %d inputs", len(parsed.Data), len(texts))
+	}
+
+	out := make([][]float64, len(texts))
+	for _, item := range parsed.Data {
+		if item.Index < 0 || item.Index >= len(out) {
+			return nil, fmt.Errorf("embeddings API index %d out of range", item.Index)
+		}
+		if out[item.Index] != nil {
+			return nil, fmt.Errorf("embeddings API duplicate index %d", item.Index)
+		}
+		out[item.Index] = item.Embedding
+	}
+	for i, v := range out {
+		if v == nil {
+			return nil, fmt.Errorf("embeddings API missing index %d", i)
+		}
+	}
+	return out, nil
+}
+
+func (o *OpenAI) embeddingsURL() string {
+	if strings.HasSuffix(o.baseURL, "/v1") {
+		return o.baseURL + "/embeddings"
+	}
+	return o.baseURL + "/v1/embeddings"
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "..."
+}

--- a/pkg/embed/openai_test.go
+++ b/pkg/embed/openai_test.go
@@ -1,0 +1,118 @@
+package embed
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOpenAIEmbedBatch(t *testing.T) {
+	t.Parallel()
+
+	var gotCalls int
+	var gotInput []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCalls++
+		if r.URL.Path != "/v1/embeddings" {
+			t.Errorf("path=%s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer sk-test" {
+			t.Errorf("auth=%s", r.Header.Get("Authorization"))
+		}
+		raw, _ := io.ReadAll(r.Body)
+		var req openaiRequest
+		if err := json.Unmarshal(raw, &req); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+		gotInput = req.Input
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(openaiResponse{
+			Data: []struct {
+				Index     int       `json:"index"`
+				Embedding []float64 `json:"embedding"`
+			}{
+				{Index: 1, Embedding: []float64{0, 1}},
+				{Index: 0, Embedding: []float64{1, 0}},
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	cli, err := NewOpenAI(srv.Client(), srv.URL, "sk-test", "test-model")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := cli.Embed([]string{"cats", "quantum"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotCalls != 1 {
+		t.Fatalf("calls=%d want 1 (batch)", gotCalls)
+	}
+	if len(gotInput) != 2 || gotInput[0] != "cats" || gotInput[1] != "quantum" {
+		t.Fatalf("input=%v", gotInput)
+	}
+	if len(got) != 2 || got[0][0] != 1 || got[1][1] != 1 {
+		t.Fatalf("vectors not ordered by index: %v", got)
+	}
+}
+
+func TestOpenAIHTTPError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad key"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cli, err := NewOpenAI(srv.Client(), srv.URL, "sk-bad", "test-model")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cli.Embed([]string{"hi"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestOpenAIRequiresKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewOpenAI(nil, "", "", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestOpenAIEmptyBatch(t *testing.T) {
+	t.Parallel()
+
+	cli, err := NewOpenAI(http.DefaultClient, "http://127.0.0.1:1", "sk", "m")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := cli.Embed(nil)
+	if err != nil || got != nil {
+		t.Fatalf("got %v %v", got, err)
+	}
+}
+
+func TestLookup(t *testing.T) {
+	t.Parallel()
+
+	e, err := Lookup("hashing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := e.(Hashing); !ok {
+		t.Fatalf("got %T", e)
+	}
+	_, err = Lookup("nope")
+	if err == nil {
+		t.Fatal("expected unknown embedder")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `embed.OpenAI`: one HTTP POST per `Embed` batch, reuse `http.Client`.
- `embed.Lookup("hashing"|"openai")`. openai needs `OPENAI_API_KEY` (optional `OPENAI_BASE_URL`, `OPENAI_EMBED_MODEL`).
- CLI `-embedder`; API field `embedder`. Used by semantic chunking and `-index`.
- Tests use `httptest` only.

## Test plan
- [x] `go test ./...`
- [ ] Mock server: two inputs, one call, vectors ordered by `index` even if the API returns them swapped.
- [ ] `-embedder magic` exits 2.