### PR TITLE
Add POST /v1/index to keep embeddings in memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ go run ./cmd/nibble-api -addr 127.0.0.1:8080
 | --- | --- | --- |
 | `GET` | `/health` | liveness |
 | `POST` | `/v1/chunk` | chunk JSON body |
+| `POST` | `/v1/index` | chunk, embed, keep in process memory |
 
 `POST /v1/chunk` body:
 
@@ -66,7 +67,7 @@ go run ./cmd/nibble-api -addr 127.0.0.1:8080
 }
 ```
 
-Omitted fields use the same defaults as the CLI. Response: `{"chunks":[...]}`.
+Omitted fields use the same defaults as the CLI. `POST /v1/chunk` returns `{"chunks":[...]}`. `POST /v1/index` uses the same body and returns `{"count":N}`. Search over that index is a later endpoint.
 
 ## Development
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -8,15 +8,32 @@ import (
 	"github.com/bluesky585/nibble/internal/buildchunk"
 	"github.com/bluesky585/nibble/pkg/chunk"
 	"github.com/bluesky585/nibble/pkg/embed"
+	"github.com/bluesky585/nibble/pkg/store"
 )
 
 const maxBody = 10 << 20
 
-// Handler is the HTTP API.
+// API holds process-local indexed chunks.
+type API struct {
+	mem *store.Memory
+}
+
+// New returns an API with an empty memory store.
+func New() *API {
+	return &API{mem: &store.Memory{}}
+}
+
+// Handler is the HTTP API. Each call gets its own memory index.
 func Handler() http.Handler {
+	return New().Handler()
+}
+
+// Handler serves health, chunk, and index routes.
+func (a *API) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", health)
 	mux.HandleFunc("POST /v1/chunk", chunkText)
+	mux.HandleFunc("POST /v1/index", a.indexText)
 	return mux
 }
 
@@ -37,19 +54,44 @@ type chunkResponse struct {
 	Chunks []chunk.Chunk `json:"chunks"`
 }
 
+type indexResponse struct {
+	Count int `json:"count"`
+}
+
 type errorResponse struct {
 	Error string `json:"error"`
 }
 
 func chunkText(w http.ResponseWriter, r *http.Request) {
+	chunks, _, status, err := prepare(w, r)
+	if err != nil {
+		writeJSON(w, status, errorResponse{Error: err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, chunkResponse{Chunks: chunks})
+}
+
+func (a *API) indexText(w http.ResponseWriter, r *http.Request) {
+	chunks, emb, status, err := prepare(w, r)
+	if err != nil {
+		writeJSON(w, status, errorResponse{Error: err.Error()})
+		return
+	}
+	if err := store.Index(a.mem, emb, chunks); err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, indexResponse{Count: len(chunks)})
+}
+
+func prepare(w http.ResponseWriter, r *http.Request) ([]chunk.Chunk, embed.Embedder, int, error) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxBody)
 
 	var req chunkRequest
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
-		return
+		return nil, nil, http.StatusBadRequest, err
 	}
 
 	if req.Chunker == "" {
@@ -64,25 +106,22 @@ func chunkText(w http.ResponseWriter, r *http.Request) {
 
 	emb, err := embed.Lookup(req.Embedder)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
-		return
+		return nil, nil, http.StatusBadRequest, err
 	}
 
 	c, err := buildchunk.New(req.Chunker, req.Tokenizer, req.Size, req.Overlap, emb)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
-		return
+		return nil, nil, http.StatusBadRequest, err
 	}
 
 	chunks, err := c.Chunk(req.Text)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: err.Error()})
-		return
+		return nil, nil, http.StatusInternalServerError, err
 	}
 	if chunks == nil {
 		chunks = []chunk.Chunk{}
 	}
-	writeJSON(w, http.StatusOK, chunkResponse{Chunks: chunks})
+	return chunks, emb, 0, nil
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/bluesky585/nibble/internal/assertchunk"
+	"github.com/bluesky585/nibble/pkg/embed"
 )
 
 func TestHealth(t *testing.T) {
@@ -21,6 +22,53 @@ func TestHealth(t *testing.T) {
 		t.Fatalf("status %d", rec.Code)
 	}
 	if !strings.Contains(rec.Body.String(), `"ok": true`) {
+		t.Fatalf("body=%s", rec.Body.String())
+	}
+}
+
+func TestIndexStores(t *testing.T) {
+	t.Parallel()
+
+	api := New()
+	body := `{"text":"cats sleep. quantum field.","chunker":"sentence","size":64}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/index", strings.NewReader(body))
+	api.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp indexResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Count < 1 {
+		t.Fatalf("count=%d", resp.Count)
+	}
+
+	q, err := embed.Hashing{}.Embed([]string{"cats"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits, err := api.mem.Search(q[0], 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || !strings.Contains(hits[0].Record.Chunk.Text, "cats") {
+		t.Fatalf("got %+v", hits)
+	}
+}
+
+func TestIndexEmpty(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/index", strings.NewReader(`{"text":""}`))
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"count": 0`) {
 		t.Fatalf("body=%s", rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary
- Add `POST /v1/index` with the same body as `/v1/chunk`.
- Embeds chunks in one batch and upserts into a process-local memory store.
- Response: `{\"count\":N}`. `POST /v1/search` is not in this PR.

## Test plan
- [x] `go test ./...` (~99 lines changed)
- [ ] Index `cats sleep. quantum field.` then memory search for `cats` hits the cat chunk.