### PR TITLE
Add POST /v1/search over the in-memory index

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ go run ./cmd/nibble-api -addr 127.0.0.1:8080
 | `GET` | `/health` | liveness |
 | `POST` | `/v1/chunk` | chunk JSON body |
 | `POST` | `/v1/index` | chunk, embed, keep in process memory |
+| `POST` | `/v1/search` | cosine search over that memory index |
 
 `POST /v1/chunk` body:
 
@@ -67,7 +68,9 @@ go run ./cmd/nibble-api -addr 127.0.0.1:8080
 }
 ```
 
-Omitted fields use the same defaults as the CLI. `POST /v1/chunk` returns `{"chunks":[...]}`. `POST /v1/index` uses the same body and returns `{"count":N}`. Search over that index is a later endpoint.
+Omitted fields use the same defaults as the CLI. `POST /v1/chunk` returns `{"chunks":[...]}`. `POST /v1/index` uses the same body and returns `{"count":N}`.
+
+`POST /v1/search` body: `{"query":"cats","k":1,"embedder":"hashing"}`. `k` defaults to 5. Index and search must hit the same process.
 
 ## Development
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -4,6 +4,7 @@ package httpapi
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/bluesky585/nibble/internal/buildchunk"
 	"github.com/bluesky585/nibble/pkg/chunk"
@@ -28,12 +29,13 @@ func Handler() http.Handler {
 	return New().Handler()
 }
 
-// Handler serves health, chunk, and index routes.
+// Handler serves health, chunk, index, and search routes.
 func (a *API) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", health)
 	mux.HandleFunc("POST /v1/chunk", chunkText)
 	mux.HandleFunc("POST /v1/index", a.indexText)
+	mux.HandleFunc("POST /v1/search", a.searchText)
 	return mux
 }
 
@@ -56,6 +58,16 @@ type chunkResponse struct {
 
 type indexResponse struct {
 	Count int `json:"count"`
+}
+
+type searchRequest struct {
+	Query    string `json:"query"`
+	K        int    `json:"k"`
+	Embedder string `json:"embedder"`
+}
+
+type searchResponse struct {
+	Hits []store.Hit `json:"hits"`
 }
 
 type errorResponse struct {
@@ -82,6 +94,45 @@ func (a *API) indexText(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, indexResponse{Count: len(chunks)})
+}
+
+func (a *API) searchText(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBody)
+
+	var req searchRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+		return
+	}
+	if strings.TrimSpace(req.Query) == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "query is required"})
+		return
+	}
+	if req.K == 0 {
+		req.K = 5
+	}
+
+	emb, err := embed.Lookup(req.Embedder)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+		return
+	}
+	vecs, err := emb.Embed([]string{req.Query})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: err.Error()})
+		return
+	}
+	hits, err := a.mem.Search(vecs[0], req.K)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+		return
+	}
+	if hits == nil {
+		hits = []store.Hit{}
+	}
+	writeJSON(w, http.StatusOK, searchResponse{Hits: hits})
 }
 
 func prepare(w http.ResponseWriter, r *http.Request) ([]chunk.Chunk, embed.Embedder, int, error) {

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -59,6 +59,52 @@ func TestIndexStores(t *testing.T) {
 	}
 }
 
+func TestSearchAfterIndex(t *testing.T) {
+	t.Parallel()
+
+	api := New()
+	h := api.Handler()
+
+	idx := httptest.NewRecorder()
+	h.ServeHTTP(idx, httptest.NewRequest(
+		http.MethodPost,
+		"/v1/index",
+		strings.NewReader(`{"text":"cats sleep. quantum field.","chunker":"sentence","size":64}`),
+	))
+	if idx.Code != http.StatusOK {
+		t.Fatalf("index status %d body=%s", idx.Code, idx.Body.String())
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(
+		http.MethodPost,
+		"/v1/search",
+		strings.NewReader(`{"query":"cats","k":1}`),
+	))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("search status %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp searchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Hits) != 1 || !strings.Contains(resp.Hits[0].Record.Chunk.Text, "cats") {
+		t.Fatalf("got %+v", resp.Hits)
+	}
+}
+
+func TestSearchRequiresQuery(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/search", strings.NewReader(`{"query":""}`))
+	Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", rec.Code)
+	}
+}
+
 func TestIndexEmpty(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add `POST /v1/search` with `{\"query\",\"k\",\"embedder\"}`.
- `k` defaults to 5. Empty query is 400.
- Hits come from the process-local store filled by `/v1/index`.

## Test plan
- [x] `go test ./...` (~102 lines)
- [x] Index `cats sleep. quantum field.` then search `cats` with `k=1`.