### PR TITLE
Add overlap.Prefix to copy previous tokens into Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 
 `-index` writes chunks plus vectors from the selected embedder to JSONL.
 
+`overlap.Prefix` copies the previous chunk's last tokens into `context` without changing `text`, so reconstruct still holds. It is a library helper; the CLI does not call it yet.
+
 ## HTTP API
 
 ```bash

--- a/pkg/overlap/overlap.go
+++ b/pkg/overlap/overlap.go
@@ -1,0 +1,52 @@
+// Package overlap copies neighboring tokens into Chunk.Context.
+// Text and offsets are unchanged, so reconstruct still holds.
+package overlap
+
+import (
+	"fmt"
+
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+// Prefix sets each chunk's Context to the last n tokens of the previous
+// chunk. Existing Context is kept in front. The first chunk is unchanged
+// except for a copy.
+func Prefix(chunks []chunk.Chunk, tok tokenizer.Tokenizer, n int) ([]chunk.Chunk, error) {
+	if tok == nil {
+		return nil, fmt.Errorf("tokenizer is required")
+	}
+	if n < 0 {
+		return nil, fmt.Errorf("n must be >= 0, got %d", n)
+	}
+	if len(chunks) == 0 {
+		return nil, nil
+	}
+
+	out := make([]chunk.Chunk, len(chunks))
+	copy(out, chunks)
+	if n == 0 {
+		return out, nil
+	}
+
+	for i := 1; i < len(out); i++ {
+		tail := lastTokens(tok, out[i-1].Text, n)
+		if tail == "" {
+			continue
+		}
+		if out[i].Context != "" {
+			out[i].Context += tail
+		} else {
+			out[i].Context = tail
+		}
+	}
+	return out, nil
+}
+
+func lastTokens(tok tokenizer.Tokenizer, text string, n int) string {
+	parts := tok.Split(text)
+	if n >= len(parts) {
+		return text
+	}
+	return tokenizer.Join(parts[len(parts)-n:])
+}

--- a/pkg/overlap/overlap_test.go
+++ b/pkg/overlap/overlap_test.go
@@ -1,0 +1,105 @@
+package overlap
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bluesky585/nibble/internal/assertchunk"
+	"github.com/bluesky585/nibble/pkg/chunk"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
+)
+
+func mustChunk(t *testing.T, text string, start int) chunk.Chunk {
+	t.Helper()
+	end := start
+	for range text {
+		end++
+	}
+	c, err := chunk.New(text, start, end, end-start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestPrefix(t *testing.T) {
+	t.Parallel()
+
+	original := "hello world"
+	chunks := []chunk.Chunk{
+		mustChunk(t, "hello ", 0),
+		mustChunk(t, "world", 6),
+	}
+
+	got, err := Prefix(chunks, tokenizer.Character{}, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if got[0].Context != "" {
+		t.Fatalf("first context=%q", got[0].Context)
+	}
+	if got[1].Context != "lo " {
+		t.Fatalf("second context=%q want %q", got[1].Context, "lo ")
+	}
+	if got[1].Text != "world" {
+		t.Fatalf("text must stay %q", got[1].Text)
+	}
+}
+
+func TestPrefixKeepsExistingContext(t *testing.T) {
+	t.Parallel()
+
+	chunks := []chunk.Chunk{
+		mustChunk(t, "ab", 0),
+		mustChunk(t, "cd", 2),
+	}
+	chunks[1].Context = "H|"
+
+	got, err := Prefix(chunks, tokenizer.Character{}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[1].Context != "H|b" {
+		t.Fatalf("context=%q", got[1].Context)
+	}
+}
+
+func TestPrefixZero(t *testing.T) {
+	t.Parallel()
+
+	chunks := []chunk.Chunk{mustChunk(t, "ab", 0), mustChunk(t, "cd", 2)}
+	got, err := Prefix(chunks, tokenizer.Character{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[1].Context != "" {
+		t.Fatalf("context=%q", got[1].Context)
+	}
+}
+
+func TestPrefixShortPrevious(t *testing.T) {
+	t.Parallel()
+
+	chunks := []chunk.Chunk{mustChunk(t, "ab", 0), mustChunk(t, "cd", 2)}
+	got, err := Prefix(chunks, tokenizer.Character{}, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[1].Context != "ab" {
+		t.Fatalf("context=%q", got[1].Context)
+	}
+}
+
+func TestPrefixValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := Prefix(nil, nil, 1)
+	if err == nil || !strings.Contains(err.Error(), "tokenizer is required") {
+		t.Fatalf("err=%v", err)
+	}
+	_, err = Prefix(nil, tokenizer.Character{}, -1)
+	if err == nil || !strings.Contains(err.Error(), "n must be >= 0") {
+		t.Fatalf("err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `overlap.Prefix`: last n tokens of chunk i-1 go into chunk i `Context`.
- `Text` / offsets are unchanged, so reconstruct still holds.
- Existing `Context` is kept in front. CLI is not wired yet.

## Test plan
- [x] `go test ./...` (+159 lines)
- [x] `"hello world"` split as `hello ` + `world`, n=3 → second `context` is `lo `
- [x] Existing context `H|` plus 1-token overlap → `H|b`
- [x] n=0 leaves context empty; n larger than the previous chunk copies all of it