### PR TITLE
Add overlap.Suffix to copy following tokens into Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 
 `-index` writes chunks plus vectors from the selected embedder to JSONL.
 
-`overlap.Prefix` copies the previous chunk's last tokens into `context` without changing `text`, so reconstruct still holds. It is a library helper; the CLI does not call it yet.
+`overlap.Prefix` / `overlap.Suffix` copy neighboring tokens into `context` without changing `text`, so reconstruct still holds. The CLI does not call them yet.
 
 ## HTTP API
 

--- a/pkg/overlap/overlap.go
+++ b/pkg/overlap/overlap.go
@@ -13,6 +13,32 @@ import (
 // chunk. Existing Context is kept in front. The first chunk is unchanged
 // except for a copy.
 func Prefix(chunks []chunk.Chunk, tok tokenizer.Tokenizer, n int) ([]chunk.Chunk, error) {
+	out, err := copyForOverlap(chunks, tok, n)
+	if err != nil || n == 0 || len(out) == 0 {
+		return out, err
+	}
+
+	for i := 1; i < len(out); i++ {
+		out[i].Context = appendContext(out[i].Context, lastTokens(tok, out[i-1].Text, n))
+	}
+	return out, nil
+}
+
+// Suffix sets each chunk's Context to the first n tokens of the next
+// chunk. Existing Context is kept in front. The last chunk is unchanged
+// except for a copy.
+func Suffix(chunks []chunk.Chunk, tok tokenizer.Tokenizer, n int) ([]chunk.Chunk, error) {
+	out, err := copyForOverlap(chunks, tok, n)
+	if err != nil || n == 0 || len(out) == 0 {
+		return out, err
+	}
+	for i := 0; i < len(out)-1; i++ {
+		out[i].Context = appendContext(out[i].Context, firstTokens(tok, out[i+1].Text, n))
+	}
+	return out, nil
+}
+
+func copyForOverlap(chunks []chunk.Chunk, tok tokenizer.Tokenizer, n int) ([]chunk.Chunk, error) {
 	if tok == nil {
 		return nil, fmt.Errorf("tokenizer is required")
 	}
@@ -22,25 +48,19 @@ func Prefix(chunks []chunk.Chunk, tok tokenizer.Tokenizer, n int) ([]chunk.Chunk
 	if len(chunks) == 0 {
 		return nil, nil
 	}
-
 	out := make([]chunk.Chunk, len(chunks))
 	copy(out, chunks)
-	if n == 0 {
-		return out, nil
-	}
-
-	for i := 1; i < len(out); i++ {
-		tail := lastTokens(tok, out[i-1].Text, n)
-		if tail == "" {
-			continue
-		}
-		if out[i].Context != "" {
-			out[i].Context += tail
-		} else {
-			out[i].Context = tail
-		}
-	}
 	return out, nil
+}
+
+func appendContext(existing, extra string) string {
+	if extra == "" {
+		return existing
+	}
+	if existing == "" {
+		return extra
+	}
+	return existing + extra
 }
 
 func lastTokens(tok tokenizer.Tokenizer, text string, n int) string {
@@ -49,4 +69,12 @@ func lastTokens(tok tokenizer.Tokenizer, text string, n int) string {
 		return text
 	}
 	return tokenizer.Join(parts[len(parts)-n:])
+}
+
+func firstTokens(tok tokenizer.Tokenizer, text string, n int) string {
+	parts := tok.Split(text)
+	if n >= len(parts) {
+		return text
+	}
+	return tokenizer.Join(parts[:n])
 }

--- a/pkg/overlap/overlap_test.go
+++ b/pkg/overlap/overlap_test.go
@@ -91,6 +91,58 @@ func TestPrefixShortPrevious(t *testing.T) {
 	}
 }
 
+func TestSuffix(t *testing.T) {
+	t.Parallel()
+
+	original := "hello world"
+	chunks := []chunk.Chunk{
+		mustChunk(t, "hello ", 0),
+		mustChunk(t, "world", 6),
+	}
+
+	got, err := Suffix(chunks, tokenizer.Character{}, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, got)
+	if got[0].Context != "wor" {
+		t.Fatalf("first context=%q want wor", got[0].Context)
+	}
+	if got[1].Context != "" {
+		t.Fatalf("last context=%q", got[1].Context)
+	}
+	if got[0].Text != "hello " {
+		t.Fatalf("text must stay %q", got[0].Text)
+	}
+}
+
+func TestSuffixKeepsExistingContext(t *testing.T) {
+	t.Parallel()
+
+	chunks := []chunk.Chunk{
+		mustChunk(t, "ab", 0),
+		mustChunk(t, "cd", 2),
+	}
+	chunks[0].Context = "H|"
+
+	got, err := Suffix(chunks, tokenizer.Character{}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Context != "H|c" {
+		t.Fatalf("context=%q", got[0].Context)
+	}
+}
+
+func TestSuffixValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := Suffix(nil, nil, 1)
+	if err == nil || !strings.Contains(err.Error(), "tokenizer is required") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestPrefixValidation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add `overlap.Suffix`: first n tokens of chunk i+1 go into chunk i `Context`.
- `Text` / offsets are unchanged. Existing `Context` is kept in front.
- Share copy/append helpers with `Prefix`.

## Test plan
- [x] `go test ./...` (+96 / -16)
- [x] `"hello world"` as `hello ` + `world`, n=3 → first `context` is `wor`
- [x] Existing context `H|` plus 1-token suffix → `H|c`