### PR TITLE
Wire overlap Prefix and Suffix into the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 | `-overlap` | `0` | token overlap; token chunker only |
 | `-index` | | optional JSONL file of chunk embeddings |
 | `-embedder` | `hashing` | `hashing` or `openai` (used by `semantic` and `-index`) |
+| `-context` | `0` | neighbor tokens copied into `context` (0 disables) |
+| `-context-mode` | `prefix` | `prefix` or `suffix` |
 
 `fast` looks for a delimiter near the byte budget and never splits a UTF-8 rune. JSON `start`/`end` are still rune offsets.
 
@@ -42,7 +44,7 @@ Reads a UTF-8 file, or stdin if no path is given. Prints a JSON array of chunks.
 
 `-index` writes chunks plus vectors from the selected embedder to JSONL.
 
-`overlap.Prefix` / `overlap.Suffix` copy neighboring tokens into `context` without changing `text`, so reconstruct still holds. The CLI does not call them yet.
+`-context` / `-context-mode` copy neighboring tokens into `context` without changing `text`, so reconstruct still holds. This is separate from `-overlap` (token windows).
 
 ## HTTP API
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -12,7 +12,9 @@ import (
 	"github.com/bluesky585/nibble/internal/buildchunk"
 	"github.com/bluesky585/nibble/pkg/chunk"
 	"github.com/bluesky585/nibble/pkg/embed"
+	olap "github.com/bluesky585/nibble/pkg/overlap"
 	"github.com/bluesky585/nibble/pkg/store"
+	"github.com/bluesky585/nibble/pkg/tokenizer"
 )
 
 // Run parses args, chunks input, and writes JSON chunks to stdout.
@@ -32,6 +34,8 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	overlap := fs.Int("overlap", 0, "token overlap (token chunker only)")
 	indexPath := fs.String("index", "", "optional JSONL path to store chunk embeddings")
 	embedderName := fs.String("embedder", "hashing", "embedder: hashing or openai (semantic and -index)")
+	contextN := fs.Int("context", 0, "neighbor tokens copied into chunk context (0 disables)")
+	contextMode := fs.String("context-mode", "prefix", "prefix or suffix (used with -context)")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -64,6 +68,27 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		chunks = []chunk.Chunk{}
 	}
 
+	if *contextN != 0 {
+		tok, err := tokenizerFromName(*tokName)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 2
+		}
+		switch *contextMode {
+		case "prefix":
+			chunks, err = olap.Prefix(chunks, tok, *contextN)
+		case "suffix":
+			chunks, err = olap.Suffix(chunks, tok, *contextN)
+		default:
+			fmt.Fprintf(stderr, "unknown context-mode %q\n", *contextMode)
+			return 2
+		}
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 2
+		}
+	}
+
 	if *indexPath != "" {
 		st, err := store.OpenJSONL(*indexPath)
 		if err != nil {
@@ -83,6 +108,17 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+func tokenizerFromName(name string) (tokenizer.Tokenizer, error) {
+	switch name {
+	case "", "character":
+		return tokenizer.Character{}, nil
+	case "word":
+		return tokenizer.Word{}, nil
+	default:
+		return nil, fmt.Errorf("unknown tokenizer %q", name)
+	}
 }
 
 func readInput(files []string, stdin io.Reader) (string, error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -156,6 +156,56 @@ func TestRunFast(t *testing.T) {
 	}
 }
 
+func TestRunContextPrefix(t *testing.T) {
+	t.Parallel()
+
+	original := "hello"
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "token", "-size", "3", "-context", "2", "-context-mode", "prefix"}, strings.NewReader(original), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+
+	var chunks []chunk.Chunk
+	if err := json.Unmarshal(stdout.Bytes(), &chunks); err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, chunks)
+	if len(chunks) != 2 || chunks[1].Context != "el" {
+		t.Fatalf("got %+v", chunks)
+	}
+}
+
+func TestRunContextSuffix(t *testing.T) {
+	t.Parallel()
+
+	original := "hello"
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-chunker", "token", "-size", "3", "-context", "2", "-context-mode", "suffix"}, strings.NewReader(original), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+
+	var chunks []chunk.Chunk
+	if err := json.Unmarshal(stdout.Bytes(), &chunks); err != nil {
+		t.Fatal(err)
+	}
+	assertchunk.Split(t, original, chunks)
+	if len(chunks) != 2 || chunks[0].Context != "lo" {
+		t.Fatalf("got %+v", chunks)
+	}
+}
+
+func TestRunUnknownContextMode(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-context", "1", "-context-mode", "sideways"}, strings.NewReader("hello"), &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit %d want 2 stderr=%s", code, stderr.String())
+	}
+}
+
 func TestRunTokenOverlap(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add `-context N` and `-context-mode prefix|suffix`.
- Neighbor tokens are copied into `context`; `text` still reconstructs.
- Separate from `-overlap` (token window overlap).

## Test plan
- [x] `go test ./...` (+89 / -1)
- [x] token size 3 on `hello` with `-context 2 -context-mode prefix` → second `context` is `el`
- [x] same with suffix → first `context` is `lo`
- [x] unknown `-context-mode` exits 2