### PR TITLE
Add MIT license, install docs, and GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+      - name: gofmt
+        run: test -z "$(gofmt -l .)"
+      - name: go test
+        run: go test ./...

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 bluesky585
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,34 @@ A Go library for splitting long text into retrieval-sized chunks for RAG.
 
 The name means a small bite: chunks should be small enough to retrieve on their own, and complete enough to keep context.
 
+## Install
+
+Requires Go 1.26+. Until a version tag exists, pin `@main`:
+
+```bash
+go get github.com/bluesky585/nibble@main
+go install github.com/bluesky585/nibble/cmd/nibble@main
+go install github.com/bluesky585/nibble/cmd/nibble-api@main
+```
+
 ## Principles
 
 - **Reconstructable.** With no overlap, concatenating chunks in order must equal the original text.
 - **Correct offsets.** Each chunk carries a half-open range `[Start, End)`. Offsets count Unicode code points (`rune` in Go), not bytes.
 - **Deterministic.** The same input and config always produce the same chunks.
 - **Separate measures.** Characters, bytes, and tokens are different rulers. Do not mix them.
-- **Small core.** Get chunking right first. Document parsing, embeddings, and vector stores are out of scope for now.
+- **Small core.** Chunking is the product. Embeddings and stores are swap-in interfaces, not a catalog of vendors.
 - **English only.** Code, comments, commit messages, and docs in this repo are written in English.
+
+## v0.1 status
+
+This is a first cut, not a production RAG platform.
+
+- Default tokenizer counts runes, not tiktoken.
+- `-embedder hashing` is bag-of-words similarity, not a neural model.
+- `POST /v1/index` lives in process memory; it is gone when the server exits.
+- `code` parses Go only.
+- There is no directory batch command and no query CLI yet.
 
 ## CLI
 
@@ -85,3 +105,7 @@ go test ./...
 go build -o nibble ./cmd/nibble
 go build -o nibble-api ./cmd/nibble-api
 ```
+
+## License
+
+MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- Add MIT `LICENSE`.
- README: install via `@main`, v0.1 limits, drop the stale \"out of scope\" line.
- GitHub Actions: `gofmt` + `go test ./...` on `main` and pull requests.

## Test plan
- [x] `go test ./...`
- [x] `gofmt -l .` is empty
- [x] diff is +65 / -1